### PR TITLE
Travis-CI: add go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
   - 1.10.x
   - tip
 
+go_import_path: github.com/maxatome/go-deeptest
+
 script:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
The `go_import_path` option of Travis-CI (see [doc](https://docs.travis-ci.com/user/languages/go/)) allows to tell Travis-CI the path where the code should be cloned in $GOPATH.
This allows external contributors to use Travis-CI on their fork without incorrectly running the testsuite with the original import path instead of their modified code.