### PR TITLE
Maximal number of errors reported by each comparison func settable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ func TestCreateRecord(tt *testing.T) {
   record, err := CreateRecord("Bob", 23)
 
   if t.Nil(err) {
-    t.Struct(record,
+    t.RootName("RECORD").Struct(record,
       Record{
         Name: "Bob",
         Age:  23,
@@ -139,7 +139,7 @@ func TestCreateRecord(tt *testing.T) {
 ## Installation
 
 ```sh
-$ go get github.com/maxatome/go-testdeep
+$ go get -u github.com/maxatome/go-testdeep
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func TestCreateRecord(t *testing.T) {
 
   if td.CmpNil(t, err) {
     td.CmpStruct(t, record,
-      Record{
+      &Record{
         Name: "Bob",
         Age:  23,
       },
@@ -88,7 +88,6 @@ expected "Bob", output would have been:
     DATA.Name: values differ
            got: (string) (len=5) "Alice"
       expected: (string) (len=3) "Bob"
-    [called by CmpStruct at td_between_test.go:37]
 FAIL
 exit status 1
 FAIL  github.com/maxatome/go-testdeep  0.006s

--- a/context.go
+++ b/context.go
@@ -8,10 +8,59 @@ package testdeep
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"unsafe"
 )
+
+// ContextConfig allows to configure finely how tests failures are rendered.
+//
+// See NewT function to use it.
+type ContextConfig struct {
+	// RootName is the string used to represent the root of got data. It
+	// defaults to "DATA". For an HTTP response body, it could be "BODY"
+	// for example.
+	RootName string
+	// MaxErrors is the maximal number of errors to dump in case of Cmp*
+	// failure.
+	//
+	// It defaults to 1 except if the environment variable
+	// TESTDEEP_MAX_ERRORS is set. In this latter case, the
+	// TESTDEEP_MAX_ERRORS value is converted to an int and used as is.
+	//
+	// Setting it to 0 has the same effect as 1.
+	//
+	// Setting it to a negative number means no limit: all errors
+	// will be dumped.
+	MaxErrors int
+}
+
+const contextDefaultRootName = "DATA"
+
+// DefaultContextConfig is the default configuration used to render
+// tests failures. If overridden, new settings will impact all Cmp*
+// functions and *T methods (if not specifically configured.)
+var DefaultContextConfig = ContextConfig{
+	RootName: contextDefaultRootName,
+	MaxErrors: func() (n int) {
+		n, err := strconv.Atoi(os.Getenv("TESTDEEP_MAX_ERRORS"))
+		if err != nil || n == 0 {
+			n = 1
+		}
+		return
+	}(),
+}
+
+func (c *ContextConfig) sanitize() {
+	if c.RootName == "" {
+		c.RootName = DefaultContextConfig.RootName
+	}
+	if c.MaxErrors == 0 {
+		c.MaxErrors = DefaultContextConfig.MaxErrors
+	}
+}
 
 type visit struct {
 	a1  unsafe.Pointer
@@ -22,21 +71,38 @@ type visit struct {
 // Context is used internally to keep track of the CmpDeeply in-depth
 // traversal.
 type Context struct {
-	path    string
-	depth   int
-	visited map[visit]bool
+	path        string
+	depth       int
+	visited     map[visit]bool
+	curOperator TestDeep
 	// If true, the contents of the returned *Error will not be
 	// checked. Can be used to avoid filling Error{} with expensive
 	// computations.
 	booleanError bool
+	// 0 ≤ maxErrors ≤ 1 stops when first error encoutered, else accumulate
+	// maxErrors > 1 stops when maxErrors'th error encoutered
+	// < 0 do not stop until comparison ends
+	maxErrors int
+	errors    *[]*Error
 }
 
-// NewContext creates a new Context using path.
-func NewContext(path string) Context {
-	return Context{
-		path:    path,
-		visited: map[visit]bool{},
+// NewContext creates a new Context using DefaultContextConfig configuration.
+func NewContext() Context {
+	return NewContextWithConfig(DefaultContextConfig)
+}
+
+// NewContextWithConfig creates a new Context using a specific configuration.
+func NewContextWithConfig(config ContextConfig) (ctx Context) {
+	config.sanitize()
+
+	ctx = Context{
+		path:      config.RootName,
+		visited:   map[visit]bool{},
+		maxErrors: config.MaxErrors,
 	}
+
+	ctx.initErrors()
+	return
 }
 
 // NewBooleanContext creates a new boolean Context.
@@ -45,6 +111,61 @@ func NewBooleanContext() Context {
 		visited:      map[visit]bool{},
 		booleanError: true,
 	}
+}
+
+func (c *Context) initErrors() {
+	if c.maxErrors != 0 && c.maxErrors != 1 {
+		errors := make([]*Error, 0)
+		c.errors = &errors
+	}
+}
+
+func (c Context) resetErrors() (new Context) {
+	new = c
+	new.initErrors()
+	return
+}
+
+// CollectError collects an error in the context. It returns an error
+// if the collector is full, nil otherwise.
+func (c Context) CollectError(err *Error) *Error {
+	if err == nil {
+		return nil
+	}
+
+	// Error context not initialized yet
+	if err.Context.depth == 0 {
+		err.Context = c
+	}
+
+	if !err.Location.IsInitialized() && c.curOperator != nil {
+		err.Location = c.curOperator.GetLocation()
+	}
+
+	// Stop when first error encoutered
+	if c.errors == nil {
+		return err
+	}
+
+	// Else, accumulate...
+	*c.errors = append(*c.errors, err)
+	if c.maxErrors >= 0 && len(*c.errors) >= c.maxErrors {
+		return c.mergeErrors()
+	}
+	return nil
+}
+
+func (c Context) mergeErrors() *Error {
+	if c.errors == nil || len(*c.errors) == 0 {
+		return nil
+	}
+
+	if len(*c.errors) > 1 {
+		for idx, last := 0, len(*c.errors)-2; idx <= last; idx++ {
+			(*c.errors)[idx].Next = (*c.errors)[idx+1]
+		}
+	}
+	return (*c.errors)[0]
 }
 
 // AddDepth creates a new Context from current one plus pathAdd.

--- a/context_test.go
+++ b/context_test.go
@@ -23,20 +23,63 @@ func equalStr(t *testing.T, got, expected string) bool {
 }
 
 func TestContext(t *testing.T) {
-	equalStr(t, NewContext("test").path, "test")
+	equalStr(t, NewContext().path, "DATA")
 	equalStr(t, NewBooleanContext().path, "")
 
-	equalStr(t, NewContext("test").AddDepth(".foo").path, "test.foo")
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test"}).
+			AddDepth(".foo").
+			path,
+		"test.foo")
 
-	equalStr(t, NewContext("test").AddDepth(".foo").AddDepth(".bar").path,
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test"}).
+			AddDepth(".foo").
+			AddDepth(".bar").
+			path,
 		"test.foo.bar")
 
-	equalStr(t, NewContext("*test").AddDepth(".foo").path, "(*test).foo")
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "*test"}).
+			AddDepth(".foo").
+			path,
+		"(*test).foo")
 
-	equalStr(t, NewContext("test").AddArrayIndex(12).path, "test[12]")
-	equalStr(t, NewContext("*test").AddArrayIndex(12).path, "(*test)[12]")
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test"}).
+			AddArrayIndex(12).path,
+		"test[12]")
 
-	equalStr(t, NewContext("test").AddPtr(2).path, "**test")
-	equalStr(t, NewContext("test.foo").AddPtr(1).path, "*test.foo")
-	equalStr(t, NewContext("test[3]").AddPtr(1).path, "*test[3]")
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "*test"}).
+			AddArrayIndex(12).path,
+		"(*test)[12]")
+
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test"}).
+			AddPtr(2).
+			path,
+		"**test")
+
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test.foo"}).
+			AddPtr(1).path, "*test.foo")
+
+	equalStr(t,
+		NewContextWithConfig(ContextConfig{RootName: "test[3]"}).
+			AddPtr(1).path,
+		"*test[3]")
+
+	if NewContextWithConfig(ContextConfig{MaxErrors: -1}).CollectError(nil) != nil {
+		t.Errorf("ctx.CollectError(nil) should return nil")
+	}
+
+	ctx := ContextConfig{}
+	if ctx == DefaultContextConfig {
+		t.Errorf("Empty ContextConfig should be ≠ from DefaultContextConfig")
+	}
+	ctx.sanitize()
+	if ctx != DefaultContextConfig {
+		t.Errorf("Sanitized empty ContextConfig should be = to DefaultContextConfig")
+	}
 }

--- a/error.go
+++ b/error.go
@@ -98,14 +98,10 @@ func (e *Error) Append(buf *bytes.Buffer, prefix string) {
 	}
 
 	if e.Location.IsInitialized() &&
-		//!strings.HasPrefix(e.Location.Func, "Cmp") && // no need to log Cmp* func
+		!strings.HasPrefix(e.Location.Func, "Cmp") && // no need to log Cmp* func
 		(e.Next == nil || e.Next.Location != e.Location) {
 		writeEolPrefix()
-		if strings.HasPrefix(e.Location.Func, "Cmp") {
-			buf.WriteString("[called by ")
-		} else {
-			buf.WriteString("[under TestDeep operator ")
-		}
+		buf.WriteString("[under TestDeep operator ")
 		buf.WriteString(e.Location.String())
 		buf.WriteByte(']')
 	}

--- a/error.go
+++ b/error.go
@@ -28,17 +28,43 @@ type Error struct {
 	Location Location
 	// If defined, the current Error comes from this Error
 	Origin *Error
+	// If defined, points to the next Error
+	Next *Error
 }
 
 var booleanError = &Error{}
 
 // Error implements error interface.
 func (e *Error) Error() string {
+	buf := bytes.Buffer{}
+
+	e.Append(&buf, "")
+
+	return buf.String()
+}
+
+// Append appends the Error contents to "buf" using prefix "prefix"
+// for each line.
+func (e *Error) Append(buf *bytes.Buffer, prefix string) {
 	if e == booleanError {
-		return ""
+		return
 	}
 
-	buf := &bytes.Buffer{}
+	var writeEolPrefix func()
+	if prefix != "" {
+		eolPrefix := make([]byte, 1+len(prefix))
+		eolPrefix[0] = '\n'
+		copy(eolPrefix[1:], prefix)
+
+		writeEolPrefix = func() {
+			buf.Write(eolPrefix)
+		}
+		buf.WriteString(prefix)
+	} else {
+		writeEolPrefix = func() {
+			buf.WriteByte('\n')
+		}
+	}
 
 	if pos := strings.Index(e.Message, "%%"); pos >= 0 {
 		buf.WriteString(e.Message[:pos])
@@ -50,35 +76,44 @@ func (e *Error) Error() string {
 		buf.WriteString(e.Message)
 	}
 
-	buf.WriteByte('\n')
+	writeEolPrefix()
 
 	if e.Summary != nil {
 		buf.WriteByte('\t')
-		buf.WriteString(indentString(e.SummaryString(), "\t"))
+		buf.WriteString(indentString(e.SummaryString(), prefix+"\t"))
 	} else {
 		buf.WriteString("\t     got: ")
-		buf.WriteString(indentString(e.GotString(), "\t          "))
-		buf.WriteString("\n\texpected: ")
-		buf.WriteString(indentString(e.ExpectedString(), "\t          "))
+		buf.WriteString(indentString(e.GotString(), prefix+"\t          "))
+		writeEolPrefix()
+		buf.WriteString("\texpected: ")
+		buf.WriteString(indentString(e.ExpectedString(), prefix+"\t          "))
 	}
 
-	if e.Location.IsInitialized() {
+	// This error comes from another one
+	if e.Origin != nil {
+		writeEolPrefix()
+		buf.WriteString("Originates from following error:\n")
+
+		e.Origin.Append(buf, prefix+"\t")
+	}
+
+	if e.Location.IsInitialized() &&
+		//!strings.HasPrefix(e.Location.Func, "Cmp") && // no need to log Cmp* func
+		(e.Next == nil || e.Next.Location != e.Location) {
+		writeEolPrefix()
 		if strings.HasPrefix(e.Location.Func, "Cmp") {
-			buf.WriteString("\n[called by ")
+			buf.WriteString("[called by ")
 		} else {
-			buf.WriteString("\n[under TestDeep operator ")
+			buf.WriteString("[under TestDeep operator ")
 		}
 		buf.WriteString(e.Location.String())
 		buf.WriteByte(']')
 	}
 
-	// This error comes from another one
-	if e.Origin != nil {
-		buf.WriteString("\nOriginates from following error:\n\t")
-		buf.WriteString(indentString(e.Origin.Error(), "\t"))
+	if e.Next != nil {
+		buf.WriteByte('\n')
+		e.Next.Append(buf, prefix) // next error at same level
 	}
-
-	return buf.String()
 }
 
 // GotString returns the string corresponding to the Got
@@ -108,13 +143,4 @@ func (e *Error) SummaryString() string {
 		return ""
 	}
 	return toString(e.Summary)
-}
-
-// SetLocationIfMissing initializes the Error Location field if it not
-// initialized yet, with the location of the passed TestDeep operator.
-func (e *Error) SetLocationIfMissing(t TestDeep) *Error {
-	if e != nil && !e.Location.IsInitialized() {
-		e.Location = t.GetLocation()
-	}
-	return e
 }

--- a/error_test.go
+++ b/error_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestError(t *testing.T) {
 	err := Error{
-		Context:  NewContext("DATA[12].Field"),
+		Context:  NewContextWithConfig(ContextConfig{RootName: "DATA[12].Field"}),
 		Message:  "Error message",
 		Got:      1,
 		Expected: 2,
@@ -43,7 +43,7 @@ func TestError(t *testing.T) {
 	expected: (int) 2`)
 
 	err = Error{
-		Context:  NewContext("DATA[12].Field"),
+		Context:  NewContextWithConfig(ContextConfig{RootName: "DATA[12].Field"}),
 		Message:  "Error message",
 		Got:      1,
 		Expected: 2,
@@ -60,7 +60,7 @@ func TestError(t *testing.T) {
 [under TestDeep operator Operator at file.go:23]`)
 
 	err = Error{
-		Context: NewContext("DATA[12].Field"),
+		Context: NewContextWithConfig(ContextConfig{RootName: "DATA[12].Field"}),
 		Message: "Error message",
 		Summary: 666,
 		Location: Location{
@@ -69,7 +69,8 @@ func TestError(t *testing.T) {
 			Line: 23,
 		},
 		Origin: &Error{
-			Context: NewContext("DATA[12].Field<All#1/2>"),
+			Context: NewContextWithConfig(
+				ContextConfig{RootName: "DATA[12].Field<All#1/2>"}),
 			Message: "Origin error message",
 			Summary: 42,
 			Location: Location{
@@ -82,9 +83,96 @@ func TestError(t *testing.T) {
 	equalStr(t, err.Error(),
 		`DATA[12].Field: Error message
 	(int) 666
-[under TestDeep operator Operator at file.go:23]
 Originates from following error:
 	DATA[12].Field<All#1/2>: Origin error message
 		(int) 42
-	[under TestDeep operator SubOperator at file2.go:236]`)
+	[under TestDeep operator SubOperator at file2.go:236]
+[under TestDeep operator Operator at file.go:23]`)
+
+	err = Error{
+		Context: NewContextWithConfig(ContextConfig{RootName: "DATA[12].Field"}),
+		Message: "Error message",
+		Summary: 666,
+		Location: Location{
+			File: "file.go",
+			Func: "Operator",
+			Line: 23,
+		},
+		Origin: &Error{
+			Context: NewContextWithConfig(
+				ContextConfig{RootName: "DATA[12].Field<All#1/2>"}),
+			Message: "Origin error message",
+			Summary: 42,
+			Location: Location{
+				File: "file2.go",
+				Func: "SubOperator",
+				Line: 236,
+			},
+		},
+		// Next error at same location
+		Next: &Error{
+			Context: NewContextWithConfig(ContextConfig{RootName: "DATA[13].Field"}),
+			Message: "Error message",
+			Summary: 888,
+			Location: Location{
+				File: "file.go",
+				Func: "Operator",
+				Line: 23,
+			},
+		},
+	}
+	equalStr(t, err.Error(),
+		`DATA[12].Field: Error message
+	(int) 666
+Originates from following error:
+	DATA[12].Field<All#1/2>: Origin error message
+		(int) 42
+	[under TestDeep operator SubOperator at file2.go:236]
+DATA[13].Field: Error message
+	(int) 888
+[under TestDeep operator Operator at file.go:23]`)
+
+	err = Error{
+		Context: NewContextWithConfig(ContextConfig{RootName: "DATA[12].Field"}),
+		Message: "Error message",
+		Summary: 666,
+		Location: Location{
+			File: "file.go",
+			Func: "Operator",
+			Line: 23,
+		},
+		Origin: &Error{
+			Context: NewContextWithConfig(
+				ContextConfig{RootName: "DATA[12].Field<All#1/2>"}),
+			Message: "Origin error message",
+			Summary: 42,
+			Location: Location{
+				File: "file2.go",
+				Func: "SubOperator",
+				Line: 236,
+			},
+		},
+		// Next error at different location
+		Next: &Error{
+			Context: NewContextWithConfig(ContextConfig{RootName: "DATA[13].Field"}),
+			Message: "Error message",
+			Summary: 888,
+			Location: Location{
+				File: "file.go",
+				Func: "Operator",
+				Line: 24,
+			},
+		},
+	}
+	equalStr(t, err.Error(),
+		`DATA[12].Field: Error message
+	(int) 666
+Originates from following error:
+	DATA[12].Field<All#1/2>: Origin error message
+		(int) 42
+	[under TestDeep operator SubOperator at file2.go:236]
+[under TestDeep operator Operator at file.go:23]
+DATA[13].Field: Error message
+	(int) 888
+[under TestDeep operator Operator at file.go:24]`)
 }

--- a/t_struct.go
+++ b/t_struct.go
@@ -43,7 +43,7 @@ type T struct {
 //       t.Log("No error, can now check struct contents")
 //
 //       ok := t.Struct(record,
-//         Record{
+//         &Record{
 //           Name: "Bob",
 //           Age:  23,
 //         },
@@ -137,7 +137,7 @@ func NewT(t *testing.T, config ...ContextConfig) *T {
 //
 //   t.RootName("RECORD").
 //     Struct(record,
-//       Record{
+//       &Record{
 //         Name: "Bob",
 //         Age:  23,
 //       },

--- a/t_struct.go
+++ b/t_struct.go
@@ -14,6 +14,7 @@ import (
 // testing.T methods as well as T ones.
 type T struct {
 	*testing.T
+	Config ContextConfig // defaults to DefaultContextConfig
 }
 
 // NewT returns a new T instance. Typically used as:
@@ -31,7 +32,9 @@ type T struct {
 //   }
 //
 //   func TestCreateRecord(tt *testing.T) {
-//     t := NewT(tt)
+//     t := NewT(tt, ContextConfig{
+//       MaxErrors: 3, // in case of failure, will dump up to 3 errors
+//     })
 //
 //     before := time.Now()
 //     record, err := CreateRecord()
@@ -54,32 +57,133 @@ type T struct {
 //       }
 //     }
 //   }
-func NewT(t *testing.T) *T {
-	return &T{
-		T: t,
+//
+// "config" is an optional argument and, if passed, must be unique. It
+// allows to configure how failures will be rendered during the life
+// time of the returned instance.
+//
+//   t := NewT(tt)
+//   t.CmpDeeply(
+//     Record{Age: 12, Name: "Bob", Id: 12},  // got
+//     Record{Age: 21, Name: "John", Id: 28}) // expected
+//
+// will produce:
+//
+//   === RUN   TestFoobar
+//   --- FAIL: TestFoobar (0.00s)
+//   	foobar_test.go:88: Failed test
+//   		DATA.Id: values differ
+//   			     got: (uint64) 12
+//   			expected: (uint64) 28
+//   FAIL
+//
+// Now with a special configuration:
+//
+//   t := NewT(tt, ContextConfig{
+//       RootName:  "RECORD", // got data named "RECORD" instead of "DATA"
+//       MaxErrors: 2,        // stops after 2 errors instead of 1
+//     })
+//   t.CmpDeeply(
+//     Record{Age: 12, Name: "Bob", Id: 12},  // got
+//     Record{Age: 21, Name: "John", Id: 28}) // expected
+//
+// will produce:
+//
+//   === RUN   TestFoobar
+//   --- FAIL: TestFoobar (0.00s)
+//   	foobar_test.go:96: Failed test
+//   		RECORD.Id: values differ
+//   			     got: (uint64) 12
+//   			expected: (uint64) 28
+//   		RECORD.Name: values differ
+//   			     got: (string) (len=3) "Bob"
+//   			expected: (string) (len=4) "John"
+//   FAIL
+//
+// See RootName method to configure RootName in a more specific fashion.
+//
+// Note that setting MaxErrors to a negative value produces a dump
+// with all errors.
+//
+// If MaxErrors is not set (or set to 0), it is set to
+// DefaultContextConfig.MaxErrors which is potentially dependent from
+// the TESTDEEP_MAX_ERRORS environment variable. See ContextConfig
+// documentation for details.
+func NewT(t *testing.T, config ...ContextConfig) *T {
+	switch len(config) {
+	case 0:
+		return &T{
+			T:      t,
+			Config: DefaultContextConfig,
+		}
+
+	case 1:
+		config[0].sanitize()
+		return &T{
+			T:      t,
+			Config: config[0],
+		}
+
+	default:
+		panic("usage: NewT(*testing.T[, ContextConfig]")
 	}
 }
 
-// CmpDeeply is shortcut for:
+// RootName changes the name of the got data. By default it is
+// "DATA". For an HTTP response body, it could be "BODY" for example.
+//
+// It returns a new instance of *T so does not alter the original t
+// and used as follows:
+//
+//   t.RootName("RECORD").
+//     Struct(record,
+//       Record{
+//         Name: "Bob",
+//         Age:  23,
+//       },
+//       td.StructFields{
+//         Id:        td.Not(uint64(0)),
+//         CreatedAt: td.Between(before, time.Now()),
+//       },
+//       "Newly created record")
+//
+// In case of error for the field Age, the failure message will contain:
+//
+//   RECORD.Age: values differ
+//
+// Which is more readable than the generic:
+//
+//   DATA.Age: values differ
+func (t *T) RootName(rootName string) *T {
+	new := *t
+	new.Config.RootName = rootName
+	return &new
+}
+
+// CmpDeeply is mostly a shortcut for:
 //
 //   CmpDeeply(t.T, got, expected, args...)
+//
+// with the exception that t.Config is used to configure the test
+// Context.
 func (t *T) CmpDeeply(got, expected interface{}, args ...interface{}) bool {
 	t.Helper()
-	return CmpDeeply(t.T, got, expected, args...)
+	return cmpDeeply(NewContextWithConfig(t.Config),
+		t.T, got, expected, args...)
 }
 
 // True is shortcut for:
 //
-//   CmpDeeply(t.T, got, true, args...)
+//   t.CmpDeeply(got, true, args...)
 func (t *T) True(got interface{}, args ...interface{}) bool {
 	t.Helper()
-	return CmpDeeply(t.T, got, true, args...)
+	return t.CmpDeeply(got, true, args...)
 }
 
 // False is shortcut for:
 //
-//   CmpDeeply(t.T, got, false, args...)
+//   t.CmpDeeply(got, false, args...)
 func (t *T) False(got interface{}, args ...interface{}) bool {
 	t.Helper()
-	return CmpDeeply(t.T, got, false, args...)
+	return t.CmpDeeply(got, false, args...)
 }

--- a/t_struct_test.go
+++ b/t_struct_test.go
@@ -44,3 +44,31 @@ func ExampleT_False() {
 	// true
 	// false
 }
+
+func TestT(tt *testing.T) {
+	t := NewT(tt)
+	CmpDeeply(tt, t.Config, DefaultContextConfig)
+
+	t = NewT(tt, ContextConfig{})
+	CmpDeeply(tt, t.Config, DefaultContextConfig)
+
+	conf := ContextConfig{
+		RootName:  "TEST",
+		MaxErrors: 33,
+	}
+	t = NewT(tt, conf)
+	CmpDeeply(tt, t.Config, conf)
+
+	t2 := t.RootName("T2")
+	CmpDeeply(tt, t.Config, conf)
+	CmpDeeply(tt, t2.Config, ContextConfig{
+		RootName:  "T2",
+		MaxErrors: 33,
+	})
+
+	//
+	// Bad usage
+	checkPanic(tt,
+		func() { NewT(tt, ContextConfig{}, ContextConfig{}) },
+		"usage: NewT")
+}

--- a/td_any.go
+++ b/td_any.go
@@ -34,11 +34,9 @@ func (a *tdAny) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "comparing with Any",
 		Got:      got,
 		Expected: a,
-		Location: a.GetLocation(),
-	}
+	})
 }

--- a/td_array_each.go
+++ b/td_array_each.go
@@ -34,13 +34,11 @@ func (a *tdArrayEach) Match(ctx Context, got reflect.Value) (err *Error) {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "nil value",
 			Got:      rawString("nil"),
 			Expected: rawString("Slice OR Array OR *Slice OR *Array"),
-			Location: a.GetLocation(),
-		}
+		})
 	}
 
 	switch got.Kind() {
@@ -50,13 +48,11 @@ func (a *tdArrayEach) Match(ctx Context, got reflect.Value) (err *Error) {
 			if ctx.booleanError {
 				return booleanError
 			}
-			return &Error{
-				Context:  ctx,
+			return ctx.CollectError(&Error{
 				Message:  "nil pointer",
 				Got:      rawString("nil " + got.Type().String()),
 				Expected: rawString("Slice OR Array OR *Slice OR *Array"),
-				Location: a.GetLocation(),
-			}
+			})
 		}
 
 		if gotElem.Kind() != reflect.Array && gotElem.Kind() != reflect.Slice {
@@ -68,10 +64,11 @@ func (a *tdArrayEach) Match(ctx Context, got reflect.Value) (err *Error) {
 	case reflect.Array, reflect.Slice:
 		gotLen := got.Len()
 
+		var err *Error
 		for idx := 0; idx < gotLen; idx++ {
 			err = deepValueEqual(ctx.AddArrayIndex(idx), got.Index(idx), a.expected)
 			if err != nil {
-				return err.SetLocationIfMissing(a)
+				return err
 			}
 		}
 		return nil
@@ -80,13 +77,11 @@ func (a *tdArrayEach) Match(ctx Context, got reflect.Value) (err *Error) {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "bad type",
 		Got:      rawString(got.Type().String()),
 		Expected: rawString("Slice OR Array OR *Slice OR *Array"),
-		Location: a.GetLocation(),
-	}
+	})
 }
 
 func (a *tdArrayEach) String() string {

--- a/td_between.go
+++ b/td_between.go
@@ -386,13 +386,11 @@ func (b *tdBetween) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "type mismatch",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(b.expectedMin.Type().String()),
-			Location: b.GetLocation(),
-		}
+		})
 	}
 
 	var ok bool
@@ -415,13 +413,11 @@ func (b *tdBetween) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "values differ",
 		Got:      rawString(fmt.Sprintf("%v", got.Interface())),
 		Expected: rawString(b.String()),
-		Location: b.GetLocation(),
-	}
+	})
 }
 
 func (b *tdBetween) String() string {
@@ -464,18 +460,16 @@ func (b *tdBetweenTime) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "type mismatch",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(b.expectedType.String()),
-			Location: b.GetLocation(),
-		}
+		})
 	}
 
 	cmpGot, err := getTime(ctx, got, b.mustConvert)
 	if err != nil {
-		return err
+		return ctx.CollectError(err)
 	}
 
 	var ok bool
@@ -508,13 +502,11 @@ func (b *tdBetweenTime) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "values differ",
 		Got:      rawString(fmt.Sprintf("%v", got.Interface())),
 		Expected: rawString(b.String()),
-		Location: b.GetLocation(),
-	}
+	})
 }
 
 func (b *tdBetweenTime) TypeBehind() reflect.Type {

--- a/td_code.go
+++ b/td_code.go
@@ -78,13 +78,11 @@ func (c *tdCode) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "incompatible parameter type",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(c.argType.String()),
-			Location: c.GetLocation(),
-		}
+		})
 	}
 
 	// Refuse to override unexported fields access in this case. It is a
@@ -94,11 +92,10 @@ func (c *tdCode) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context: ctx,
+		return ctx.CollectError(&Error{
 			Message: "cannot compare unexported field",
 			Summary: rawString("use Code() on surrounding struct instead"),
-		}
+		})
 	}
 
 	ret := c.function.Call([]reflect.Value{got})
@@ -111,9 +108,7 @@ func (c *tdCode) Match(ctx Context, got reflect.Value) *Error {
 	}
 
 	err := Error{
-		Context:  ctx,
-		Message:  "ran code with %% as argument",
-		Location: c.GetLocation(),
+		Message: "ran code with %% as argument",
 	}
 
 	if len(ret) > 1 {
@@ -127,7 +122,7 @@ func (c *tdCode) Match(ctx Context, got reflect.Value) *Error {
 		}
 	}
 
-	return &err
+	return ctx.CollectError(&err)
 }
 
 func (c *tdCode) String() string {

--- a/td_isa.go
+++ b/td_isa.go
@@ -49,7 +49,7 @@ func Isa(model interface{}) TestDeep {
 	}
 }
 
-func (i *tdIsa) Match(ctx Context, got reflect.Value) (err *Error) {
+func (i *tdIsa) Match(ctx Context, got reflect.Value) *Error {
 	gotType := got.Type()
 
 	if gotType == i.expectedType {
@@ -65,13 +65,11 @@ func (i *tdIsa) Match(ctx Context, got reflect.Value) (err *Error) {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "type mismatch",
 		Got:      rawString(gotType.String()),
 		Expected: rawString(i.expectedType.String()),
-		Location: i.GetLocation(),
-	}
+	})
 }
 
 func (i *tdIsa) String() string {

--- a/td_len_cap.go
+++ b/td_len_cap.go
@@ -52,16 +52,15 @@ func (l *tdLen) String() string {
 	return fmt.Sprintf("len=%d", l.expectedValue.Int())
 }
 
-func (l *tdLen) Match(ctx Context, got reflect.Value) (err *Error) {
+func (l *tdLen) Match(ctx Context, got reflect.Value) *Error {
 	switch got.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
 		if l.isTestDeeper {
 			vlen := reflect.New(intType)
 			vlen.Elem().SetInt(int64(got.Len()))
 
-			err = deepValueEqual(ctx.AddFunctionCall("len"),
+			return deepValueEqual(ctx.AddFunctionCall("len"),
 				vlen.Elem(), l.expectedValue)
-			return err.SetLocationIfMissing(l)
 		}
 
 		if got.Len() == int(l.expectedValue.Int()) {
@@ -70,25 +69,21 @@ func (l *tdLen) Match(ctx Context, got reflect.Value) (err *Error) {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "bad length",
 			Got:      rawInt(got.Len()),
 			Expected: rawInt(l.expectedValue.Int()),
-			Location: l.GetLocation(),
-		}
+		})
 
 	default:
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "bad type",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString("Array, Chan, Map, Slice or string"),
-			Location: l.GetLocation(),
-		}
+		})
 	}
 }
 
@@ -133,16 +128,15 @@ func (c *tdCap) String() string {
 	return fmt.Sprintf("cap=%d", c.expectedValue.Int())
 }
 
-func (c *tdCap) Match(ctx Context, got reflect.Value) (err *Error) {
+func (c *tdCap) Match(ctx Context, got reflect.Value) *Error {
 	switch got.Kind() {
 	case reflect.Array, reflect.Chan, reflect.Slice:
 		if c.isTestDeeper {
 			vcap := reflect.New(intType)
 			vcap.Elem().SetInt(int64(got.Cap()))
 
-			err = deepValueEqual(ctx.AddFunctionCall("cap"),
+			return deepValueEqual(ctx.AddFunctionCall("cap"),
 				vcap.Elem(), c.expectedValue)
-			return err.SetLocationIfMissing(c)
 		}
 
 		if got.Cap() == int(c.expectedValue.Int()) {
@@ -151,24 +145,20 @@ func (c *tdCap) Match(ctx Context, got reflect.Value) (err *Error) {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "bad capacity",
 			Got:      rawInt(got.Cap()),
 			Expected: rawInt(c.expectedValue.Int()),
-			Location: c.GetLocation(),
-		}
+		})
 
 	default:
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "bad type",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString("Array, Chan or Slice"),
-			Location: c.GetLocation(),
-		}
+		})
 	}
 }

--- a/td_map_each.go
+++ b/td_map_each.go
@@ -28,18 +28,16 @@ func MapEach(expectedValue interface{}) TestDeep {
 	}
 }
 
-func (m *tdMapEach) Match(ctx Context, got reflect.Value) (err *Error) {
+func (m *tdMapEach) Match(ctx Context, got reflect.Value) *Error {
 	if !got.IsValid() {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "nil value",
 			Got:      rawString("nil"),
 			Expected: rawString("Map OR *Map"),
-			Location: m.GetLocation(),
-		}
+		})
 	}
 
 	switch got.Kind() {
@@ -49,13 +47,11 @@ func (m *tdMapEach) Match(ctx Context, got reflect.Value) (err *Error) {
 			if ctx.booleanError {
 				return booleanError
 			}
-			return &Error{
-				Context:  ctx,
+			return ctx.CollectError(&Error{
 				Message:  "nil pointer",
 				Got:      rawString("nil " + got.Type().String()),
 				Expected: rawString("Map OR *Map"),
-				Location: m.GetLocation(),
-			}
+			})
 		}
 
 		if gotElem.Kind() != reflect.Map {
@@ -65,11 +61,12 @@ func (m *tdMapEach) Match(ctx Context, got reflect.Value) (err *Error) {
 		fallthrough
 
 	case reflect.Map:
+		var err *Error
 		for _, key := range got.MapKeys() {
 			err = deepValueEqual(ctx.AddDepth("["+toString(key)+"]"),
 				got.MapIndex(key), m.expected)
 			if err != nil {
-				return err.SetLocationIfMissing(m)
+				return err
 			}
 		}
 		return nil
@@ -78,13 +75,11 @@ func (m *tdMapEach) Match(ctx Context, got reflect.Value) (err *Error) {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "bad type",
 		Got:      rawString(got.Type().String()),
 		Expected: rawString("Map OR *Map"),
-		Location: m.GetLocation(),
-	}
+	})
 }
 
 func (m *tdMapEach) String() string {

--- a/td_nil.go
+++ b/td_nil.go
@@ -40,13 +40,11 @@ func (n *tdNil) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "non-nil",
 		Got:      got,
 		Expected: n,
-		Location: n.GetLocation(),
-	}
+	})
 }
 
 func (n *tdNil) String() string {
@@ -85,13 +83,11 @@ func (n *tdNotNil) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "nil value",
 		Got:      got,
 		Expected: n,
-		Location: n.GetLocation(),
-	}
+	})
 }
 
 func (n *tdNotNil) String() string {

--- a/td_none.go
+++ b/td_none.go
@@ -51,13 +51,11 @@ func (n *tdNone) Match(ctx Context, got reflect.Value) *Error {
 				mesg = fmt.Sprintf("comparing with None (part %d of %d is OK)",
 					idx+1, len(n.items))
 			}
-			return &Error{
-				Context:  ctx,
+			return ctx.CollectError(&Error{
 				Message:  mesg,
 				Got:      got,
 				Expected: n,
-				Location: n.GetLocation(),
-			}
+			})
 		}
 	}
 	return nil

--- a/td_ptr.go
+++ b/td_ptr.go
@@ -40,26 +40,22 @@ func Ptr(val interface{}) TestDeep {
 	panic("usage: Ptr(NON_NIL_VALUE)")
 }
 
-func (p *tdPtr) Match(ctx Context, got reflect.Value) (err *Error) {
+func (p *tdPtr) Match(ctx Context, got reflect.Value) *Error {
 	if got.Kind() != reflect.Ptr {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "pointer type mismatch",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(p.String()),
-			Location: p.GetLocation(),
-		}
+		})
 	}
 
 	if p.isTestDeeper {
-		err = deepValueEqual(ctx.AddPtr(1), got.Elem(), p.expectedValue)
-	} else {
-		err = deepValueEqual(ctx, got, p.expectedValue)
+		return deepValueEqual(ctx.AddPtr(1), got.Elem(), p.expectedValue)
 	}
-	return err.SetLocationIfMissing(p)
+	return deepValueEqual(ctx, got, p.expectedValue)
 }
 
 func (p *tdPtr) String() string {
@@ -105,26 +101,22 @@ func PPtr(val interface{}) TestDeep {
 	panic("usage: PPtr(NON_NIL_VALUE)")
 }
 
-func (p *tdPPtr) Match(ctx Context, got reflect.Value) (err *Error) {
+func (p *tdPPtr) Match(ctx Context, got reflect.Value) *Error {
 	if got.Kind() != reflect.Ptr || got.Elem().Kind() != reflect.Ptr {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "pointer type mismatch",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(p.String()),
-			Location: p.GetLocation(),
-		}
+		})
 	}
 
 	if p.isTestDeeper {
-		err = deepValueEqual(ctx.AddPtr(2), got.Elem().Elem(), p.expectedValue)
-	} else {
-		err = deepValueEqual(ctx, got, p.expectedValue)
+		return deepValueEqual(ctx.AddPtr(2), got.Elem().Elem(), p.expectedValue)
 	}
-	return err.SetLocationIfMissing(p)
+	return deepValueEqual(ctx, got, p.expectedValue)
 }
 
 func (p *tdPPtr) String() string {

--- a/td_set_base.go
+++ b/td_set_base.go
@@ -50,13 +50,11 @@ func (s *tdSetBase) Match(ctx Context, got reflect.Value) *Error {
 			if ctx.booleanError {
 				return booleanError
 			}
-			return &Error{
-				Context:  ctx,
+			return ctx.CollectError(&Error{
 				Message:  "nil pointer",
 				Got:      rawString("nil " + got.Type().String()),
 				Expected: rawString("Slice OR Array OR *Slice OR *Array"),
-				Location: s.GetLocation(),
-			}
+			})
 		}
 
 		if gotElem.Kind() != reflect.Array && gotElem.Kind() != reflect.Slice {
@@ -155,12 +153,10 @@ func (s *tdSetBase) Match(ctx Context, got reflect.Value) *Error {
 		if res.IsEmpty() {
 			return nil
 		}
-		return &Error{
-			Context:  ctx,
-			Message:  "comparing %% as a " + s.GetLocation().Func,
-			Summary:  res,
-			Location: s.GetLocation(),
-		}
+		return ctx.CollectError(&Error{
+			Message: "comparing %% as a " + s.GetLocation().Func,
+			Summary: res,
+		})
 	}
 
 	if ctx.booleanError {
@@ -174,13 +170,11 @@ func (s *tdSetBase) Match(ctx Context, got reflect.Value) *Error {
 		gotStr = "nil"
 	}
 
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "bad type",
 		Got:      gotStr,
 		Expected: rawString("Slice OR Array OR *Slice OR *Array"),
-		Location: s.GetLocation(),
-	}
+	})
 }
 
 func (s *tdSetBase) String() string {

--- a/td_shallow.go
+++ b/td_shallow.go
@@ -63,26 +63,22 @@ func (s *tdShallow) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "bad kind",
 			Got:      rawString(got.Kind().String()),
 			Expected: rawString(s.expectedKind.String()),
-			Location: s.GetLocation(),
-		}
+		})
 	}
 
 	if got.Pointer() != s.expectedPointer {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  fmt.Sprintf("%s pointer mismatch", s.expectedKind),
 			Got:      rawString(fmt.Sprintf("0x%x", got.Pointer())),
 			Expected: rawString(fmt.Sprintf("0x%x", s.expectedPointer)),
-			Location: s.GetLocation(),
-		}
+		})
 	}
 	return nil
 }

--- a/td_string.go
+++ b/td_string.go
@@ -44,7 +44,6 @@ func getString(ctx Context, got reflect.Value) (string, *Error) {
 		return "", booleanError
 	}
 	return "", &Error{
-		Context: ctx,
 		Message: "bad type",
 		Got:     rawString(got.Type().String()),
 		Expected: rawString(
@@ -76,8 +75,7 @@ func String(expected string) TestDeep {
 func (s *tdString) Match(ctx Context, got reflect.Value) *Error {
 	str, err := getString(ctx, got)
 	if err != nil {
-		err.Location = s.GetLocation()
-		return err
+		return ctx.CollectError(err)
 	}
 
 	if str == s.expected {
@@ -86,13 +84,11 @@ func (s *tdString) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "does not match",
 		Got:      str,
 		Expected: s,
-		Location: s.GetLocation(),
-	}
+	})
 }
 
 func (s *tdString) String() string {
@@ -126,8 +122,7 @@ func HasPrefix(expected string) TestDeep {
 func (s *tdHasPrefix) Match(ctx Context, got reflect.Value) *Error {
 	str, err := getString(ctx, got)
 	if err != nil {
-		err.Location = s.GetLocation()
-		return err
+		return ctx.CollectError(err)
 	}
 
 	if strings.HasPrefix(str, s.expected) {
@@ -136,13 +131,11 @@ func (s *tdHasPrefix) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "has not prefix",
 		Got:      str,
 		Expected: s,
-		Location: s.GetLocation(),
-	}
+	})
 }
 
 func (s *tdHasPrefix) String() string {
@@ -176,8 +169,7 @@ func HasSuffix(expected string) TestDeep {
 func (s *tdHasSuffix) Match(ctx Context, got reflect.Value) *Error {
 	str, err := getString(ctx, got)
 	if err != nil {
-		err.Location = s.GetLocation()
-		return err
+		return ctx.CollectError(err)
 	}
 
 	if strings.HasSuffix(str, s.expected) {
@@ -186,13 +178,11 @@ func (s *tdHasSuffix) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "has not suffix",
 		Got:      str,
 		Expected: s,
-		Location: s.GetLocation(),
-	}
+	})
 }
 
 func (s *tdHasSuffix) String() string {
@@ -226,8 +216,7 @@ func Contains(expected string) TestDeep {
 func (s *tdContains) Match(ctx Context, got reflect.Value) *Error {
 	str, err := getString(ctx, got)
 	if err != nil {
-		err.Location = s.GetLocation()
-		return err
+		return ctx.CollectError(err)
 	}
 
 	if strings.Contains(str, s.expected) {
@@ -236,13 +225,11 @@ func (s *tdContains) Match(ctx Context, got reflect.Value) *Error {
 	if ctx.booleanError {
 		return booleanError
 	}
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "does not contain",
 		Got:      str,
 		Expected: s,
-		Location: s.GetLocation(),
-	}
+	})
 }
 
 func (s *tdContains) String() string {

--- a/td_trunc_time.go
+++ b/td_trunc_time.go
@@ -62,18 +62,16 @@ func (t *tdTruncTime) Match(ctx Context, got reflect.Value) *Error {
 		if ctx.booleanError {
 			return booleanError
 		}
-		return &Error{
-			Context:  ctx,
+		return ctx.CollectError(&Error{
 			Message:  "type mismatch",
 			Got:      rawString(got.Type().String()),
 			Expected: rawString(t.expectedType.String()),
-			Location: t.GetLocation(),
-		}
+		})
 	}
 
 	gotTime, err := getTime(ctx, got, got.Type() != timeType)
 	if err != nil {
-		return err
+		return ctx.CollectError(err)
 	}
 	gotTimeTrunc := gotTime.Truncate(t.trunc)
 
@@ -97,13 +95,11 @@ func (t *tdTruncTime) Match(ctx Context, got reflect.Value) *Error {
 		gotTruncStr = gotTimeTrunc.String()
 	}
 
-	return &Error{
-		Context:  ctx,
+	return ctx.CollectError(&Error{
 		Message:  "values differ",
 		Got:      rawString(gotRawStr + "\ntruncated to:\n" + gotTruncStr),
 		Expected: t,
-		Location: t.GetLocation(),
-	}
+	})
 }
 
 func (t *tdTruncTime) String() string {

--- a/td_zero.go
+++ b/td_zero.go
@@ -33,8 +33,7 @@ func (z *tdZero) Match(ctx Context, got reflect.Value) (err *Error) {
 	if !got.IsValid() {
 		return nil
 	}
-	return deepValueEqual(ctx, got, reflect.New(got.Type()).Elem()).
-		SetLocationIfMissing(z)
+	return deepValueEqual(ctx, got, reflect.New(got.Type()).Elem())
 }
 
 func (z *tdZero) String() string {

--- a/testdeep.go
+++ b/testdeep.go
@@ -84,7 +84,7 @@
 //     if td.CmpDeeply(t, err, nil) {
 //       td.CmpDeeply(t, record,
 //         Struct(
-//           Record{
+//           &Record{
 //             Name: "Bob",
 //             Age:  23,
 //           },
@@ -118,7 +118,7 @@
 //
 //     if td.CmpNil(t, err) {
 //       td.CmpStruct(t, record,
-//         Record{
+//         &Record{
 //           Name: "Bob",
 //           Age:  23,
 //         },
@@ -147,7 +147,7 @@
 //
 //     if t.Nil(err) {
 //       t.RootName("RECORD").Struct(record,
-//         Record{
+//         &Record{
 //           Name: "Bob",
 //           Age:  23,
 //         },

--- a/testdeep.go
+++ b/testdeep.go
@@ -146,7 +146,7 @@
 //     record, err := CreateRecord()
 //
 //     if t.Nil(err) {
-//       t.Struct(record,
+//       t.RootName("RECORD").Struct(record,
 //         Record{
 //           Name: "Bob",
 //           Age:  23,

--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,6 @@ func getTime(ctx Context, got reflect.Value, mustConvert bool) (time.Time, *Erro
 			return time.Time{}, booleanError
 		}
 		return time.Time{}, &Error{
-			Context: ctx,
 			Message: "cannot compare unexported field that cannot be overridden",
 		}
 	}


### PR DESCRIPTION
See DefaultContextConfig variable and ContextConfig type.

TESTDEEP_MAX_ERRORS environment variable can be used to externally
override ContextConfig.MaxErrors default setting:
    TESTDEEP_MAX_ERRORS=3 go test  # up to 3 errors dumped for each comp func
    TESTDEEP_MAX_ERRORS=-1 go test # all errors dumped for each comparison func

The RootName of got data is now settable too. Still in ContextConfig.

NewT() accepts now an optional ContextConfig parameter.

Error stringifigation reworked and more efficient.

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>