### PR TITLE
Dereference interfaces before calling Testdeep operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Extremely flexible golang deep comparison, extends the go testing package.
 - [Installation](#installation)
 - [Presentation](#presentation)
 - [Available operators](#available-operators)
+- [Operators vs go types](#operators-vs-go-types)
 - [See also](#see-also)
 - [License](#license)
 - [FAQ](FAQ.md)
@@ -527,6 +528,81 @@ See functions returning [`TestDeep` interface](https://godoc.org/github.com/maxa
 - [`Zero`](https://godoc.org/github.com/maxatome/go-testdeep#Zero)
   checks data against its zero'ed conterpart.
 
+
+## Operators vs go types
+
+| Operator vs go type                               | nil | bool | string | {u,}int* | float* | complex* | array | slice | map | struct      | pointer            | interface¹ | chan | func | operator |
+| ------------------------------------------------- | --- | ---- | ------ | -------- | ------ | -------- | ----- | ----- | --- | ----------- | ------------------ | ---------- | ---- | ---- | -------- |
+| [`All`](https://godoc.org/github.com/maxatome/go-testdeep#All)                 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`All`](https://godoc.org/github.com/maxatome/go-testdeep#All) |
+| [`Any`](https://godoc.org/github.com/maxatome/go-testdeep#Any)                 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Any`](https://godoc.org/github.com/maxatome/go-testdeep#Any) |
+| [`Array`](https://godoc.org/github.com/maxatome/go-testdeep#Array)             | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✗        | ✗ | ✗           | ptr on array       | ✓ | ✗ | ✗ | [`Array`](https://godoc.org/github.com/maxatome/go-testdeep#Array) |
+| [`ArrayEach`](https://godoc.org/github.com/maxatome/go-testdeep#ArrayEach)     | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`ArrayEach`](https://godoc.org/github.com/maxatome/go-testdeep#ArrayEach) |
+| [`Bag`](https://godoc.org/github.com/maxatome/go-testdeep#Bag)                 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`Bag`](https://godoc.org/github.com/maxatome/go-testdeep#Bag) |
+| [`Between`](https://godoc.org/github.com/maxatome/go-testdeep#Between)         | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | `time.Time` | ✗                  | ✓ | ✗ | ✗ | [`Between`](https://godoc.org/github.com/maxatome/go-testdeep#Between) |
+| [`Cap`](https://godoc.org/github.com/maxatome/go-testdeep#Cap)                 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ✗                  | ✓ | ✓ | ✗ | [`Cap`](https://godoc.org/github.com/maxatome/go-testdeep#Cap) |
+| [`Code`](https://godoc.org/github.com/maxatome/go-testdeep#Code)               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Code`](https://godoc.org/github.com/maxatome/go-testdeep#Code) |
+| [`Contains`](https://godoc.org/github.com/maxatome/go-testdeep#Contains)       | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✓ | ✓        | ✓ | ✗           | ✗                  | ✓ | ✗ | ✗ | [`Contains`](https://godoc.org/github.com/maxatome/go-testdeep#Contains) |
+| [`ContainsKey`](https://godoc.org/github.com/maxatome/go-testdeep#ContainsKey) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✓ | ✗           | ✗                  | ✓ | ✗ | ✗ | [`ContainsKey`](https://godoc.org/github.com/maxatome/go-testdeep#ContainsKey) |
+
+| Operator vs go type                               | nil | bool | string | {u,}int* | float* | complex* | array | slice | map | struct      | pointer            | interface¹ | chan | func | operator |
+| ------------------------------------------------- | --- | ---- | ------ | -------- | ------ | -------- | ----- | ----- | --- | ----------- | ------------------ | ---------- | ---- | ---- | -------- |
+| [`Empty`](https://godoc.org/github.com/maxatome/go-testdeep#Empty)             | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✓ | ✓        | ✓ | ✗           | ptr or/array/slice/map/string | ✓ | ✓ | ✗ | [`Empty`](https://godoc.org/github.com/maxatome/go-testdeep#Empty) |
+| [`Gt`](https://godoc.org/github.com/maxatome/go-testdeep#Gt)                   | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | `time.Time` | ✗                  | ✓ | ✗ | ✗ | [`Gt`](https://godoc.org/github.com/maxatome/go-testdeep#Gt) |
+| [`Gte`](https://godoc.org/github.com/maxatome/go-testdeep#Gte)                 | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | `time.Time` | ✗                  | ✓ | ✗ | ✗ | [`Gte`](https://godoc.org/github.com/maxatome/go-testdeep#Gte) |
+| [`HasPrefix`](https://godoc.org/github.com/maxatome/go-testdeep#HasPrefix)     | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ + `fmt.Stringer`, `error` | ✗ | ✗ | [`HasPrefix`](https://godoc.org/github.com/maxatome/go-testdeep#HasPrefix) |
+| [`HasSuffix`](https://godoc.org/github.com/maxatome/go-testdeep#HasSuffix)     | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ + `fmt.Stringer`, `error` | ✗ | ✗ | [`HasSuffix`](https://godoc.org/github.com/maxatome/go-testdeep#HasSuffix) |
+| [`Ignore`](https://godoc.org/github.com/maxatome/go-testdeep#Isa)              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Ignore`](https://godoc.org/github.com/maxatome/go-testdeep#Isa) |
+| [`Isa`](https://godoc.org/github.com/maxatome/go-testdeep#Isa)                 | ✗ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Isa`](https://godoc.org/github.com/maxatome/go-testdeep#Isa) |
+| [`Len`](https://godoc.org/github.com/maxatome/go-testdeep#Len)                 | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✓ | ✓        | ✓ | ✗           | ✗                  | ✓ | ✓ | ✗ | [`Len`](https://godoc.org/github.com/maxatome/go-testdeep#Len) |
+| [`Lt`](https://godoc.org/github.com/maxatome/go-testdeep#Lt)                   | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | `time.Time` | ✗                  | ✓ | ✗ | ✗ | [`Lt`](https://godoc.org/github.com/maxatome/go-testdeep#Lt) |
+| [`Lte`](https://godoc.org/github.com/maxatome/go-testdeep#Lte)                 | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | `time.Time` | ✗                  | ✓ | ✗ | ✗ | [`Lte`](https://godoc.org/github.com/maxatome/go-testdeep#Lte) |
+
+| Operator vs go type                               | nil | bool | string | {u,}int* | float* | complex* | array | slice | map | struct      | pointer            | interface¹ | chan | func | operator |
+| ------------------------------------------------- | --- | ---- | ------ | -------- | ------ | -------- | ----- | ----- | --- | ----------- | ------------------ | ---------- | ---- | ---- | -------- |
+| [`Map`](https://godoc.org/github.com/maxatome/go-testdeep#Map)                 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✓ | ✗           | ptr on map         | ✓ | ✗ | ✗ | [`Map`](https://godoc.org/github.com/maxatome/go-testdeep#Map) |
+| [`MapEach`](https://godoc.org/github.com/maxatome/go-testdeep#MapEach)         | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✓ | ✗           | ptr on map         | ✓ | ✗ | ✗ | [`MapEach`](https://godoc.org/github.com/maxatome/go-testdeep#MapEach) |
+| [`N`](https://godoc.org/github.com/maxatome/go-testdeep#N)                     | ✗ | ✗ | ✗ | ✓ | ✓ | todo | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ | ✗ | ✗ | [`N`](https://godoc.org/github.com/maxatome/go-testdeep#N) |
+| [`NaN`](https://godoc.org/github.com/maxatome/go-testdeep#NaN)                 | ✗ | ✗ | ✗ | ✗ | ✓ | ✗    | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ | ✗ | ✗ | [`NaN`](https://godoc.org/github.com/maxatome/go-testdeep#NaN) |
+| [`Nil`](https://godoc.org/github.com/maxatome/go-testdeep#Nil)                 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✓        | ✓ | ✗           | ✓                  | ✓ | ✓ | ✓ | [`Nil`](https://godoc.org/github.com/maxatome/go-testdeep#Nil) |
+| [`None`](https://godoc.org/github.com/maxatome/go-testdeep#None)               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`None`](https://godoc.org/github.com/maxatome/go-testdeep#None) |
+| [`NotAny`](https://godoc.org/github.com/maxatome/go-testdeep#NotAny)           | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`NotAny`](https://godoc.org/github.com/maxatome/go-testdeep#NotAny) |
+| [`Not`](https://godoc.org/github.com/maxatome/go-testdeep#Not)                 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Not`](https://godoc.org/github.com/maxatome/go-testdeep#Not) |
+| [`NotEmpty`](https://godoc.org/github.com/maxatome/go-testdeep#NotEmpty)       | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✓ | ✓        | ✓ | ✗           | ptr or/array/slice/map/string | ✓ | ✓ | ✗ | [`NotEmpty`](https://godoc.org/github.com/maxatome/go-testdeep#NotEmpty) |
+| [`NotNaN`](https://godoc.org/github.com/maxatome/go-testdeep#NotNaN)           | ✗ | ✗ | ✗ | ✗ | ✓ | ✗    | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ | ✗ | ✗ | [`NotNaN`](https://godoc.org/github.com/maxatome/go-testdeep#NotNaN) |
+
+| Operator vs go type                               | nil | bool | string | {u,}int* | float* | complex* | array | slice | map | struct      | pointer            | interface¹ | chan | func | operator |
+| ------------------------------------------------- | --- | ---- | ------ | -------- | ------ | -------- | ----- | ----- | --- | ----------- | ------------------ | ---------- | ---- | ---- | -------- |
+| [`NotNil`](https://godoc.org/github.com/maxatome/go-testdeep#NotNil)           | ✓ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✓        | ✓ | ✗           | ✓                  | ✓ | ✓ | ✓ | [`NotNil`](https://godoc.org/github.com/maxatome/go-testdeep#NotNil) |
+| [`NotZero`](https://godoc.org/github.com/maxatome/go-testdeep#NotZero)         | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`NotZero`](https://godoc.org/github.com/maxatome/go-testdeep#NotZero) |
+| [`PPtr`](https://godoc.org/github.com/maxatome/go-testdeep#PPtr)               | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✗ | ✗           | ✓                  | ✓ | ✗ | ✗ | [`PPtr`](https://godoc.org/github.com/maxatome/go-testdeep#PPtr) |
+| [`Ptr`](https://godoc.org/github.com/maxatome/go-testdeep#Ptr)                 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✗ | ✗           | ✓                  | ✓ | ✗ | ✗ | [`Ptr`](https://godoc.org/github.com/maxatome/go-testdeep#Ptr) |
+| [`Re`](https://godoc.org/github.com/maxatome/go-testdeep#Re)                   | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | `[]byte` | ✗ | ✗           | ✗                  | ✓ + `fmt.Stringer`, `error` | ✗ | ✗ | [`Re`](https://godoc.org/github.com/maxatome/go-testdeep#Re) |
+| [`ReAll`](https://godoc.org/github.com/maxatome/go-testdeep#ReAll)             | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | `[]byte` | ✗ | ✗           | ✗                  | ✓ + `fmt.Stringer`, `error` | ✗ | ✗ | [`ReAll`](https://godoc.org/github.com/maxatome/go-testdeep#ReAll) |
+| [`Set`](https://godoc.org/github.com/maxatome/go-testdeep#Set)                 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`Set`](https://godoc.org/github.com/maxatome/go-testdeep#Set) |
+| [`Shallow`](https://godoc.org/github.com/maxatome/go-testdeep#Shallow)         | ✓ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | ✓        | ✓ | ✗           | ✓                  | ✓ | ✓ | ✓ | [`Shallow`](https://godoc.org/github.com/maxatome/go-testdeep#Shallow) |
+| [`Slice`](https://godoc.org/github.com/maxatome/go-testdeep#Slice)             | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✓        | ✗ | ✗           | ptr on slice       | ✓ | ✗ | ✗ | [`Slice`](https://godoc.org/github.com/maxatome/go-testdeep#Slice) |
+| [`Smuggle`](https://godoc.org/github.com/maxatome/go-testdeep#Smuggle)         | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Smuggle`](https://godoc.org/github.com/maxatome/go-testdeep#Smuggle) |
+
+| Operator vs go type                               | nil | bool | string | {u,}int* | float* | complex* | array | slice | map | struct      | pointer            | interface¹ | chan | func | operator |
+| ------------------------------------------------- | --- | ---- | ------ | -------- | ------ | -------- | ----- | ----- | --- | ----------- | ------------------ | ---------- | ---- | ---- | -------- |
+| [`String`](https://godoc.org/github.com/maxatome/go-testdeep#String)           | ✗ | ✗ | ✓ | ✗ | ✗ | ✗    | ✗ | ✗        | ✗ | ✗           | ✗                  | ✓ + `fmt.Stringer`, `error` | ✗ | ✗ | [`String`](https://godoc.org/github.com/maxatome/go-testdeep#String) |
+| [`Struct`](https://godoc.org/github.com/maxatome/go-testdeep#Struct)           | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✓           | ptr on struct      | ✓ | ✗ | ✗ | [`Struct`](https://godoc.org/github.com/maxatome/go-testdeep#Struct) |
+| [`SubBagOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubBagOf)       | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`SubBagOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubBagOf) |
+| [`SubMapOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubMapOf)       | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✓ | ✗           | ptr on map         | ✓ | ✗ | ✗ | [`SubMapOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubMapOf) |
+| [`SubSetOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubSetOf)       | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`SubSetOf`](https://godoc.org/github.com/maxatome/go-testdeep#SubSetOf) |
+| [`SuperBagOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperBagOf)   | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`SuperBagOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperBagOf) |
+| [`SuperMapOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperMapOf)   | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✗ | ✗        | ✓ | ✗           | ptr on map         | ✓ | ✗ | ✗ | [`SuperMapOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperMapOf) |
+| [`SuperSetOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperSetOf)   | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | ✗           | ptr on array/slice | ✓ | ✗ | ✗ | [`SuperSetOf`](https://godoc.org/github.com/maxatome/go-testdeep#SuperSetOf) |
+| [`TruncTime`](https://godoc.org/github.com/maxatome/go-testdeep#TruncTime)     | ✗ | ✗ | ✗ | ✗ | ✗ | ✗    | ✓ | ✓        | ✗ | `time.Time` | todo               | ✓ | ✗ | ✗ | [`TruncTime`](https://godoc.org/github.com/maxatome/go-testdeep#TruncTime) |
+| [`Zero`](https://godoc.org/github.com/maxatome/go-testdeep#Zero)               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓    | ✓ | ✓        | ✓ | ✓           | ✓                  | ✓ | ✓ | ✓ | [`Zero`](https://godoc.org/github.com/maxatome/go-testdeep#Zero) |
+
+Legend:
+- ✗ means using this operator with this go type will always fail
+- ✓ means using this operator with this go type can succeed
+- `[]byte`, `time.Time`, ptr on X, `fmt.Stringer`, `error` means using
+  this operator with this go type can succeed
+- todo means should be implemented in future (PRs welcome :) )
+- ¹ + ✓ means using this operator with the data behind the interface can succeed
 
 ## See also
 

--- a/cmp_funcs_test.go
+++ b/cmp_funcs_test.go
@@ -1772,6 +1772,34 @@ func ExampleCmpSmuggle_complex() {
 	// true
 }
 
+func ExampleCmpSmuggle_interface() {
+	t := &testing.T{}
+
+	gotTime, err := time.Parse(time.RFC3339, "2018-05-23T12:13:14Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Do not check the struct itself, but it stringified form
+	ok := CmpSmuggle(t, gotTime, func(s fmt.Stringer) string {
+		return s.String()
+	}, "2018-05-23 12:13:14 +0000 UTC")
+	fmt.Println("stringified time.Time OK:", ok)
+
+	// If got does not implement the fmt.Stringer interface, it fails
+	// without calling the Smuggle func
+	type MyTime time.Time
+	ok = CmpSmuggle(t, MyTime(gotTime), func(s fmt.Stringer) string {
+		fmt.Println("Smuggle func called!")
+		return s.String()
+	}, "2018-05-23 12:13:14 +0000 UTC")
+	fmt.Println("stringified MyTime OK:", ok)
+
+	// Output
+	// stringified time.Time OK: true
+	// stringified MyTime OK: false
+}
+
 func ExampleCmpSmuggle_field_path() {
 	t := &testing.T{}
 

--- a/example_test.go
+++ b/example_test.go
@@ -1864,6 +1864,38 @@ func ExampleSmuggle_complex() {
 	// true
 }
 
+func ExampleSmuggle_interface() {
+	t := &testing.T{}
+
+	gotTime, err := time.Parse(time.RFC3339, "2018-05-23T12:13:14Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Do not check the struct itself, but it stringified form
+	ok := CmpDeeply(t, gotTime,
+		Smuggle(func(s fmt.Stringer) string {
+			return s.String()
+		},
+			"2018-05-23 12:13:14 +0000 UTC"))
+	fmt.Println("stringified time.Time OK:", ok)
+
+	// If got does not implement the fmt.Stringer interface, it fails
+	// without calling the Smuggle func
+	type MyTime time.Time
+	ok = CmpDeeply(t, MyTime(gotTime),
+		Smuggle(func(s fmt.Stringer) string {
+			fmt.Println("Smuggle func called!")
+			return s.String()
+		},
+			"2018-05-23 12:13:14 +0000 UTC"))
+	fmt.Println("stringified MyTime OK:", ok)
+
+	// Output
+	// stringified time.Time OK: true
+	// stringified MyTime OK: false
+}
+
 func ExampleSmuggle_field_path() {
 	t := &testing.T{}
 

--- a/t_test.go
+++ b/t_test.go
@@ -1772,6 +1772,34 @@ func ExampleT_Smuggle_complex() {
 	// true
 }
 
+func ExampleT_Smuggle_interface() {
+	t := NewT(&testing.T{})
+
+	gotTime, err := time.Parse(time.RFC3339, "2018-05-23T12:13:14Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Do not check the struct itself, but it stringified form
+	ok := t.Smuggle(gotTime, func(s fmt.Stringer) string {
+		return s.String()
+	}, "2018-05-23 12:13:14 +0000 UTC")
+	fmt.Println("stringified time.Time OK:", ok)
+
+	// If got does not implement the fmt.Stringer interface, it fails
+	// without calling the Smuggle func
+	type MyTime time.Time
+	ok = t.Smuggle(MyTime(gotTime), func(s fmt.Stringer) string {
+		fmt.Println("Smuggle func called!")
+		return s.String()
+	}, "2018-05-23 12:13:14 +0000 UTC")
+	fmt.Println("stringified MyTime OK:", ok)
+
+	// Output
+	// stringified time.Time OK: true
+	// stringified MyTime OK: false
+}
+
 func ExampleT_Smuggle_field_path() {
 	t := NewT(&testing.T{})
 

--- a/td_array_each_test.go
+++ b/td_array_each_test.go
@@ -31,6 +31,7 @@ func TestArrayEach(t *testing.T) {
 		},
 		testdeep.ArrayEach(4))
 
+	// Empty slice/array
 	checkOKForEach(t,
 		[]interface{}{
 			[0]int{},
@@ -41,11 +42,12 @@ func TestArrayEach(t *testing.T) {
 			MySlice{},
 			&MyEmptyArray{},
 			&MySlice{},
+			// nil cases
+			([]int)(nil),
+			MySlice(nil),
 		},
 		testdeep.ArrayEach(4))
 
-	checkOK(t, ([]int)(nil), testdeep.ArrayEach(4))
-	checkOK(t, MySlice(nil), testdeep.ArrayEach(4))
 	checkError(t, (*MyArray)(nil), testdeep.ArrayEach(4),
 		expectedError{
 			Message:  mustBe("nil pointer"),

--- a/td_array_test.go
+++ b/td_array_test.go
@@ -55,6 +55,15 @@ func TestArray(t *testing.T) {
 			Expected: mustBe("(int) 6"),
 		})
 
+	checkError(t, nil,
+		testdeep.Array([1]int{42}, nil),
+		expectedError{
+			Message:  mustBe("values differ"),
+			Path:     mustBe("DATA"),
+			Got:      mustBe("nil"),
+			Expected: mustContain("Array("),
+		})
+
 	//
 	// Array type
 	checkOK(t, MyArray{}, testdeep.Array(MyArray{}, nil))
@@ -233,6 +242,15 @@ func TestSlice(t *testing.T) {
 			Path:     mustBe("DATA[2]"),
 			Got:      mustBe("(int) 4"),
 			Expected: mustBe("(int) 5"),
+		})
+
+	checkError(t, nil,
+		testdeep.Slice([]int{2, 3}, nil),
+		expectedError{
+			Message:  mustBe("values differ"),
+			Path:     mustBe("DATA"),
+			Got:      mustBe("nil"),
+			Expected: mustContain("Slice("),
 		})
 
 	//

--- a/td_contains_key_test.go
+++ b/td_contains_key_test.go
@@ -23,7 +23,8 @@ func TestContainsKey(t *testing.T) {
 		testName := fmt.Sprintf("#%d: got=%v", idx, got)
 
 		checkOK(t, got, testdeep.ContainsKey(34), testName)
-		checkOK(t, got, testdeep.ContainsKey(testdeep.Between(30, 35)), testName)
+		checkOK(t, got, testdeep.ContainsKey(testdeep.Between(30, 35)),
+			testName)
 
 		checkError(t, got, testdeep.ContainsKey(35),
 			expectedError{

--- a/td_map_each_test.go
+++ b/td_map_each_test.go
@@ -94,7 +94,8 @@ func TestMapEach(t *testing.T) {
 
 	checkOK(t, map[string]interface{}{"a": nil, "b": nil, "c": nil},
 		testdeep.MapEach(nil))
-	checkError(t, map[string]interface{}{"a": nil, "b": nil, "c": nil, "d": 66},
+	checkError(t,
+		map[string]interface{}{"a": nil, "b": nil, "c": nil, "d": 66},
 		testdeep.MapEach(nil),
 		expectedError{
 			Message:  mustBe("values differ"),

--- a/td_shallow_test.go
+++ b/td_shallow_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestShallow(t *testing.T) {
+	checkOK(t, nil, nil)
+
 	//
 	// Slice
 	back := [...]int{1, 2, 3, 1, 2, 3}

--- a/td_smuggle_test.go
+++ b/td_smuggle_test.go
@@ -8,6 +8,7 @@ package testdeep_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -158,11 +159,12 @@ func TestSmuggle(t *testing.T) {
 	checkOK(t, xInt(123),
 		testdeep.Smuggle(func(n uint32) int64 { return int64(n) }, int64(123)))
 
-	type tVal struct{ Val interface{} }
-	checkOK(t, tVal{Val: int32(123)},
-		testdeep.Struct(tVal{}, testdeep.StructFields{
-			"Val": testdeep.Smuggle(func(n int64) int { return int(n) }, 123),
-		}))
+	checkOK(t, int32(123),
+		testdeep.Smuggle(func(n int64) int { return int(n) }, 123))
+
+	checkOK(t, gotTime,
+		testdeep.Smuggle(func(t fmt.Stringer) string { return t.String() },
+			"2018-05-23 12:13:14 +0000 UTC"))
 
 	//
 	// Errors
@@ -175,25 +177,12 @@ func TestSmuggle(t *testing.T) {
 			Expected: mustBe("float64"),
 		})
 
-	checkError(t, tVal{},
-		testdeep.Struct(tVal{}, testdeep.StructFields{
-			"Val": testdeep.Smuggle(func(n int64) int { return int(n) }, 123),
-		}),
+	checkError(t, nil,
+		testdeep.Smuggle(func(n int64) int { return int(n) }, 123),
 		expectedError{
 			Message:  mustBe("incompatible parameter type"),
-			Path:     mustBe("DATA.Val"),
-			Got:      mustBe("interface {}"),
-			Expected: mustBe("int64"),
-		})
-
-	checkError(t, tVal{Val: "str"},
-		testdeep.Struct(tVal{}, testdeep.StructFields{
-			"Val": testdeep.Smuggle(func(n int64) int { return int(n) }, 123),
-		}),
-		expectedError{
-			Message:  mustBe("incompatible parameter type"),
-			Path:     mustBe("DATA.Val"),
-			Got:      mustBe("string"),
+			Path:     mustBe("DATA"),
+			Got:      mustBe("nil"),
 			Expected: mustBe("int64"),
 		})
 

--- a/td_struct_test.go
+++ b/td_struct_test.go
@@ -367,7 +367,7 @@ func TestStructPrivateFields(t *testing.T) {
 		expectedError{
 			Message:  mustBe("bad type"),
 			Path:     mustBe("DATA.iface"),
-			Got:      mustBe("interface {}"),
+			Got:      mustBe("int"),
 			Expected: mustBe("string (convertible) OR fmt.Stringer OR error OR []uint8"),
 		})
 

--- a/td_trunc_time_test.go
+++ b/td_trunc_time_test.go
@@ -33,6 +33,7 @@ func TestTruncTime(t *testing.T) {
 		checkError(t, now, nowWithoutMono,
 			expectedError{
 				Message: mustBe("values differ"),
+				Path:    mustContain("DATA"),
 			})
 	}
 	checkOK(t, now, testdeep.TruncTime(nowWithoutMono))


### PR DESCRIPTION
Add Testdeep operators vs go types table in README.

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>