### PR TITLE
ctxerr.Context.Visited has now its own type

### DIFF
--- a/config.go
+++ b/config.go
@@ -89,7 +89,7 @@ func newContextWithConfig(config ContextConfig) (ctx ctxerr.Context) {
 
 	ctx = ctxerr.Context{
 		Path:           config.RootName,
-		Visited:        map[ctxerr.Visit]bool{},
+		Visited:        ctxerr.NewVisited(),
 		MaxErrors:      config.MaxErrors,
 		FailureIsFatal: config.FailureIsFatal,
 	}
@@ -101,7 +101,7 @@ func newContextWithConfig(config ContextConfig) (ctx ctxerr.Context) {
 // newBooleanContext creates a new boolean ctxerr.Context.
 func newBooleanContext() ctxerr.Context {
 	return ctxerr.Context{
-		Visited:      map[ctxerr.Visit]bool{},
+		Visited:      ctxerr.NewVisited(),
 		BooleanError: true,
 	}
 }

--- a/internal/ctxerr/context.go
+++ b/internal/ctxerr/context.go
@@ -8,26 +8,17 @@ package ctxerr
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
-	"unsafe"
 
 	"github.com/maxatome/go-testdeep/internal/location"
 	"github.com/maxatome/go-testdeep/internal/util"
 )
 
-// Visit is used by Context and its Visited map to handle cyclic references.
-type Visit struct {
-	A1  unsafe.Pointer
-	A2  unsafe.Pointer
-	Typ reflect.Type
-}
-
 // Context is used internally to keep track of the CmpDeeply in-Depth
 // traversal.
 type Context struct {
 	Path        string
-	Visited     map[Visit]bool
+	Visited     Visited
 	CurOperator location.GetLocationer
 	Depth       int
 	// 0 ≤ MaxErrors ≤ 1 stops when first error encoutered (without the

--- a/internal/ctxerr/visited.go
+++ b/internal/ctxerr/visited.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2019, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package ctxerr
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// visitKey is used by Context and its Visited map to handle cyclic references.
+type visitedKey struct {
+	a1  unsafe.Pointer
+	a2  unsafe.Pointer
+	typ reflect.Type
+}
+
+// Visited allows to remember couples of same type pointers, typically
+// to not do the same action twice if the couple has already been seen.
+type Visited map[visitedKey]bool
+
+// NewVisited returns a new Visited instance.
+func NewVisited() Visited {
+	return Visited{}
+}
+
+// Record checks and, if needed, records a new entry for (got,
+// expected) couple. It returns true if got & expected are pointers
+// and have already been seen together. It returns false otherwise.
+// It is the caller responsibilty to check that got and expected types
+// are the same.
+func (v Visited) Record(got, expected reflect.Value) bool {
+	switch got.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Interface:
+		if got.CanAddr() && expected.CanAddr() {
+			addr1 := unsafe.Pointer(got.UnsafeAddr())
+			addr2 := unsafe.Pointer(expected.UnsafeAddr())
+			if uintptr(addr1) > uintptr(addr2) {
+				// Canonicalize order to reduce number of entries in v.
+				// Assumes non-moving garbage collector.
+				addr1, addr2 = addr2, addr1
+			}
+
+			k := visitedKey{
+				a1:  addr1,
+				a2:  addr2,
+				typ: got.Type(),
+			}
+			if v[k] {
+				return true // references already seen
+			}
+
+			// Remember for later.
+			v[k] = true
+		}
+	}
+	return false
+}

--- a/internal/ctxerr/visited_test.go
+++ b/internal/ctxerr/visited_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package ctxerr_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/internal/ctxerr"
+	"github.com/maxatome/go-testdeep/internal/test"
+)
+
+func TestVisited(t *testing.T) {
+	t.Run("not a pointer", func(t *testing.T) {
+		v := ctxerr.NewVisited()
+		a, b := 1, 2
+		test.IsFalse(t, v.Record(reflect.ValueOf(a), reflect.ValueOf(b)))
+		test.IsFalse(t, v.Record(reflect.ValueOf(a), reflect.ValueOf(b)))
+	})
+
+	// Visited.Record() needs its param be addressable, that's why we
+	// use a struct pointer below
+
+	t.Run("map", func(t *testing.T) {
+		v := ctxerr.NewVisited()
+
+		type vMap struct{ m map[string]bool }
+		a, b := &vMap{m: map[string]bool{}}, &vMap{m: map[string]bool{}}
+
+		f := func(vm *vMap) reflect.Value {
+			return reflect.ValueOf(vm).Elem().Field(0)
+		}
+
+		test.IsFalse(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(b), f(a)))
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		v := ctxerr.NewVisited()
+
+		type vSlice struct{ s []string }
+		a, b := &vSlice{s: []string{}}, &vSlice{}
+
+		f := func(vm *vSlice) reflect.Value {
+			return reflect.ValueOf(vm).Elem().Field(0)
+		}
+
+		test.IsFalse(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(b), f(a)))
+	})
+
+	t.Run("ptr", func(t *testing.T) {
+		v := ctxerr.NewVisited()
+
+		type vPtr struct{ p *int }
+		n := 42
+		a, b := &vPtr{p: &n}, &vPtr{}
+
+		f := func(vm *vPtr) reflect.Value {
+			return reflect.ValueOf(vm).Elem().Field(0)
+		}
+
+		test.IsFalse(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(b), f(a)))
+	})
+
+	t.Run("interface", func(t *testing.T) {
+		v := ctxerr.NewVisited()
+
+		type vIf struct{ i interface{} }
+		a, b := &vIf{i: 42}, &vIf{}
+
+		f := func(vm *vIf) reflect.Value {
+			return reflect.ValueOf(vm).Elem().Field(0)
+		}
+
+		test.IsFalse(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(a), f(b)))
+		test.IsTrue(t, v.Record(f(b), f(a)))
+	})
+}


### PR DESCRIPTION
so deepValueEqual() is now shorter/less complex

Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>