### PR TITLE
feat(tdhttp): NewRequest() headers can be flattened with td.Flatten()

### DIFF
--- a/helpers/tdhttp/request.go
+++ b/helpers/tdhttp/request.go
@@ -17,9 +17,12 @@ import (
 	"strings"
 
 	"github.com/maxatome/go-testdeep/internal/color"
+	"github.com/maxatome/go-testdeep/internal/flat"
 )
 
 func addHeaders(req *http.Request, headers []interface{}) *http.Request {
+	headers = flat.Interfaces(headers...)
+
 	for i := 0; i < len(headers); i++ {
 		switch cur := headers[i].(type) {
 		case string:
@@ -75,6 +78,22 @@ func addHeaders(req *http.Request, headers []interface{}) *http.Request {
 //     "Content-type": []string{"application/pdf"},
 //     "X-Test":       []string{"value1", "value2"},
 //   }
+//
+// A string slice can be flatened as well. As NewRequest() expects
+// ...interface{}, td.Flatten() can help here too:
+//   strHeaders := []string{
+//     "X-Length", "666",
+//     "X-Foo", "bar",
+//   }
+//   req := NewRequest("POST", "/pdf", body, td.Flatten(strHeaders))
+//
+// Or combined with forms seen above:
+//   req := NewRequest("POST", "/pdf",
+//     "Content-type", "application/pdf",
+//     http.Header{"X-Test": []string{"value1"}},
+//     td.Flatten(strHeaders),
+//     "X-Test", "value2",
+//   )
 func NewRequest(method, target string, body io.Reader, headers ...interface{}) *http.Request {
 	return addHeaders(httptest.NewRequest(method, target, body), headers)
 }

--- a/helpers/tdhttp/request_test.go
+++ b/helpers/tdhttp/request_test.go
@@ -54,6 +54,19 @@ func TestNewRequest(tt *testing.T) {
 		})
 	})
 
+	t.Run("NewRequest header flattened", func(t *td.T) {
+		req := tdhttp.NewRequest("GET", "/path", nil,
+			td.Flatten([]string{
+				"Foo", "Bar",
+				"Zip", "Test",
+			}))
+
+		t.Cmp(req.Header, http.Header{
+			"Foo": []string{"Bar"},
+			"Zip": []string{"Test"},
+		})
+	})
+
 	t.Run("NewRequest header combined", func(t *td.T) {
 		req := tdhttp.NewRequest("GET", "/path", nil,
 			"H1", "V1",
@@ -62,11 +75,17 @@ func TestNewRequest(tt *testing.T) {
 				"H2": []string{"V1", "V2"},
 			},
 			"H2", "V3",
+			td.Flatten([]string{
+				"H2", "V4",
+				"H3", "V1",
+				"H3", "V2",
+			}),
 		)
 
 		t.Cmp(req.Header, http.Header{
 			"H1": []string{"V1", "V2"},
-			"H2": []string{"V1", "V2", "V3"},
+			"H2": []string{"V1", "V2", "V3", "V4"},
+			"H3": []string{"V1", "V2"},
 		})
 	})
 


### PR DESCRIPTION
```
  strHeaders := []string{
    "X-Length", "666",
    "X-Foo", "bar",
  }
  req := NewRequest("POST", "/pdf", body, td.Flatten(strHeaders))
```
