### PR TITLE
fix(trace): ignore internal testing/go-testdeep calls in error traces

### DIFF
--- a/internal/trace/stack.go
+++ b/internal/trace/stack.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package trace
+
+import (
+	"strings"
+)
+
+// Level is a level when retrieving a stack trace.
+type Level struct {
+	Package  string
+	Func     string
+	FileLine string
+}
+
+// Stack is a simple stack trace.
+type Stack []Level
+
+// Match returns true if the ith level of s matches pkg (if not empty)
+// and any function in anyFunc.
+//
+// If anyFunc is empty, only the package is tested.
+//
+// If a function in anyFunc ends with "*", only the prefix is checked.
+func (s Stack) Match(i int, pkg string, anyFunc ...string) bool {
+	if i < 0 {
+		i = len(s) + i
+	}
+	if i < 0 || i >= len(s) {
+		return false
+	}
+
+	level := s[i]
+
+	if pkg != "" && level.Package != pkg {
+		return false
+	}
+
+	if len(anyFunc) == 0 {
+		return true
+	}
+
+	for _, fn := range anyFunc {
+		if strings.HasSuffix(fn, "*") {
+			if strings.HasPrefix(level.Func, fn[:len(fn)-1]) {
+				return true
+			}
+		} else if level.Func == fn {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/trace/stack_test.go
+++ b/internal/trace/stack_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package trace_test
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/internal/test"
+	"github.com/maxatome/go-testdeep/internal/trace"
+)
+
+func TestStack(t *testing.T) {
+	s := trace.Stack{
+		{Package: "A", Func: "Aaa.func1"},
+		{Package: "A", Func: "Aaa.func2"},
+		{Package: "B", Func: "Bbb"},
+		{Package: "C", Func: "Ccc"},
+	}
+
+	test.IsFalse(t, s.Match(100, "A"))
+	test.IsFalse(t, s.Match(-100, "A"))
+
+	test.IsFalse(t, s.Match(3, "B"))
+	test.IsFalse(t, s.Match(-1, "B"))
+
+	test.IsTrue(t, s.Match(3, "C"))
+	test.IsTrue(t, s.Match(-1, "C"))
+
+	test.IsFalse(t, s.Match(1, "A", "Aaa.func3", "Aaa.func1"))
+	test.IsTrue(t, s.Match(1, "A", "Aaa.func3", "Aaa.func2"))
+	test.IsTrue(t, s.Match(1, "A", "Aaa.func3", "Aaa.func*"))
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -21,13 +21,6 @@ var (
 	goModDir  string
 )
 
-// Level represents a level when retrieving a trace.
-type Level struct {
-	Package  string
-	Func     string
-	FileLine string
-}
-
 func getPackage(skip ...int) string {
 	sk := 2
 	if len(skip) > 0 {
@@ -149,8 +142,8 @@ var CallersFrames = func(callers []uintptr) Frames {
 }
 
 // Retrieve retrieves a trace and returns it.
-func Retrieve(skip int, endFunction string) []Level {
-	var trace []Level
+func Retrieve(skip int, endFunction string) Stack {
+	var trace Stack
 	var pc [40]uintptr
 	if num := runtime.Callers(skip+2, pc[:]); num > 0 {
 		checkIgnore := true

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -14,9 +14,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/maxatome/go-testdeep/internal/trace"
-
 	"github.com/maxatome/go-testdeep/internal/test"
+	"github.com/maxatome/go-testdeep/internal/trace"
 )
 
 func TestIgnorePackage(t *testing.T) {

--- a/tools/gen_funcs.pl
+++ b/tools/gen_funcs.pl
@@ -540,7 +540,7 @@ my $common_links = do
         . "\n\n"
         # Helpers
         . join("\n", map "[`$_`]: $base_url/helpers/$_",
-               qw(tdhttp))
+               qw(tdhttp tdsuite tdutil))
         . "\n\n"
         # Specific links
         . "[`BeLax` config flag]: $td_url#ContextConfig\n"


### PR DESCRIPTION
- testing.Cleanup()
- (*td.T).Run() and (*td.T).RunAssertRequire()
- (*tdhttp.TestAPI).Run()
- tdsuite package