### PR TITLE
fix(JSON): nested operators in JSON params are not json.Marshal()led

### DIFF
--- a/helpers/tdhttp/request.go
+++ b/helpers/tdhttp/request.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/internal/color"
 	"github.com/maxatome/go-testdeep/internal/flat"
+	"github.com/maxatome/go-testdeep/internal/types"
 )
 
 func addHeaders(req *http.Request, headers []interface{}) *http.Request {
@@ -185,6 +186,14 @@ func Delete(target string, body io.Reader, headers ...interface{}) *http.Request
 func NewJSONRequest(method, target string, body interface{}, headers ...interface{}) *http.Request {
 	b, err := json.Marshal(body)
 	if err != nil {
+		if opErr, ok := types.AsOperatorNotJSONMarshallableError(err); ok {
+			mesg := opErr.Error()
+			switch op := opErr.Operator(); op {
+			case "JSON", "SubJSONOf", "SuperJSONOf":
+				mesg += ", use json.RawMessage() instead"
+			}
+			panic(color.Bad(mesg))
+		}
 		panic(color.Bad("JSON encoding failed: %s", err))
 	}
 

--- a/helpers/tdhttp/request_test.go
+++ b/helpers/tdhttp/request_test.go
@@ -227,8 +227,17 @@ func TestNewJSONRequest(tt *testing.T) {
 	t.Run("NewJSONRequest panic", func(t *td.T) {
 		t.CmpPanic(
 			func() { tdhttp.NewJSONRequest("GET", "/path", func() {}) },
-			td.NotEmpty(),
+			td.HasPrefix("JSON encoding failed: "),
 			"JSON encoding failed")
+
+		t.CmpPanic(
+			func() { tdhttp.NewJSONRequest("GET", "/path", td.JSONPointer("/a", 0)) },
+			"JSONPointer TestDeep operator cannot be json.Marshal'led")
+
+		// Common user mistake
+		t.CmpPanic(
+			func() { tdhttp.NewJSONRequest("GET", "/path", td.JSON(`{}`)) },
+			"JSON TestDeep operator cannot be json.Marshal'led, use json.RawMessage() instead")
 	})
 
 	// Post

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -7,6 +7,7 @@
 package types
 
 import (
+	"encoding/json"
 	"strconv"
 )
 
@@ -42,3 +43,35 @@ func (i RawInt) String() string {
 }
 
 var _ = []TestDeepStringer{RawString(""), RawInt(0)}
+
+// OperatorNotJSONMarshallableError implements error interface. It
+// is returned by (*td.TestDeep).MarshalJSON() to notice the user an
+// operator cannot be JSON Marshal'led.
+type OperatorNotJSONMarshallableError string
+
+// Error implements error interface.
+func (e OperatorNotJSONMarshallableError) Error() string {
+	return string(e) + " TestDeep operator cannot be json.Marshal'led"
+}
+
+// Operator returns the operator behind this error.
+func (e OperatorNotJSONMarshallableError) Operator() string {
+	return string(e)
+}
+
+// AsOperatorNotJSONMarshallableError checks that err is or contains
+// an OperatorNotJSONMarshallableError and if yes, returns it and
+// true.
+func AsOperatorNotJSONMarshallableError(err error) (OperatorNotJSONMarshallableError, bool) {
+	switch err := err.(type) {
+	case OperatorNotJSONMarshallableError:
+		return err, true
+
+	case *json.MarshalerError:
+		if err, ok := err.Err.(OperatorNotJSONMarshallableError); ok {
+			return err, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/types/types_private_test.go
+++ b/internal/types/types_private_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package types
+
+import (
+	"testing"
+)
+
+func TestTypes(t *testing.T) {
+	s := RawString("foo")
+	if str := s.String(); str != "foo" {
+		t.Errorf("Very weird, got %s", str)
+	}
+
+	i := RawInt(42)
+	if str := i.String(); str != "42" {
+		t.Errorf("Very weird, got %s", str)
+	}
+
+	// Only for coverage...
+	(TestDeepStamp{})._TestDeep()
+	RawString("")._TestDeep()
+	RawInt(0)._TestDeep()
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,28 +1,66 @@
-// Copyright (c) 2020, Maxime Soulé
+// Copyright (c) 2021, Maxime Soulé
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
-package types
+package types_test
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
+
+	"github.com/maxatome/go-testdeep/internal/types"
 )
 
-func TestTypes(t *testing.T) {
-	s := RawString("foo")
-	if str := s.String(); str != "foo" {
-		t.Errorf("Very weird, got %s", str)
+var _ error = types.OperatorNotJSONMarshallableError("")
+
+func TestOperatorNotJSONMarshallableError(t *testing.T) {
+	e := types.OperatorNotJSONMarshallableError("Pipo")
+
+	if e.Error() != "Pipo TestDeep operator cannot be json.Marshal'led" {
+		t.Errorf("unexpected %q", e.Error())
 	}
 
-	i := RawInt(42)
-	if str := i.String(); str != "42" {
-		t.Errorf("Very weird, got %s", str)
+	if e.Operator() != "Pipo" {
+		t.Errorf("unexpected %q", e.Operator())
 	}
 
-	// Only for coverage...
-	(TestDeepStamp{})._TestDeep()
-	RawString("")._TestDeep()
-	RawInt(0)._TestDeep()
+	t.Run("AsOperatorNotJSONMarshallableError", func(t *testing.T) {
+		ne, ok := types.AsOperatorNotJSONMarshallableError(e)
+		if !ok {
+			t.Error("AsOperatorNotJSONMarshallableError() returned false")
+			return
+		}
+		if ne != e {
+			t.Errorf("AsOperatorNotJSONMarshallableError(): %q ≠ %q",
+				ne.Error(), e.Error())
+		}
+
+		other := errors.New("Other error")
+		_, ok = types.AsOperatorNotJSONMarshallableError(other)
+		if ok {
+			t.Error("AsOperatorNotJSONMarshallableError() returned true")
+			return
+		}
+
+		je := &json.MarshalerError{Err: e}
+		ne, ok = types.AsOperatorNotJSONMarshallableError(je)
+		if !ok {
+			t.Error("AsOperatorNotJSONMarshallableError() returned false")
+			return
+		}
+		if ne != e {
+			t.Errorf("AsOperatorNotJSONMarshallableError(): %q ≠ %q",
+				ne.Error(), e.Error())
+		}
+
+		je.Err = other
+		_, ok = types.AsOperatorNotJSONMarshallableError(je)
+		if ok {
+			t.Error("AsOperatorNotJSONMarshallableError() returned true")
+			return
+		}
+	})
 }

--- a/td/td_json_test.go
+++ b/td/td_json_test.go
@@ -53,6 +53,8 @@ func TestJSON(t *testing.T) {
 	checkOK(t, got,
 		td.JSON(`{"name":"Bob","age":42,"gender":"male"}`))
 
+	checkOK(t, got, td.JSON(`$1`, got)) // json.Marshal() got for $1
+
 	// Numeric placeholders
 	checkOK(t, got,
 		td.JSON(`{"name":"$1","age":$2,"gender":$3}`,
@@ -70,6 +72,14 @@ func TestJSON(t *testing.T) {
 			td.Re(`^Bob`),
 			td.Flatten([]td.TestDeep{td.Between(40, 45), td.NotEmpty()}),
 		))
+
+	// Operators are not JSON marshallable
+	checkOK(t, got,
+		td.JSON(`$1`, map[string]interface{}{
+			"name":   td.Re(`^Bob`),
+			"age":    42,
+			"gender": td.NotEmpty(),
+		}))
 
 	// Tag placeholders
 	checkOK(t, got,

--- a/td/types.go
+++ b/td/types.go
@@ -128,6 +128,13 @@ func (t base) TypeBehind() reflect.Type {
 	return nil
 }
 
+// MarshalJSON implements encoding/json.Marshaler only to returns an
+// error, as a TestDeep operator should never be JSON marshalled. So
+// it is better to tell the user he/she does a mistake.
+func (t base) MarshalJSON() ([]byte, error) {
+	return nil, types.OperatorNotJSONMarshallableError(t.location.Func)
+}
+
 // newBase returns a new base struct with location.Location set to the
 // "callDepth" depth.
 func newBase(callDepth int) (b base) {


### PR DESCRIPTION
for safety purposes, the json.Marshal()ling is now forbidden, but an
explicit error message is returned to the user.