### PR TITLE
fix(tdsuite): Cleanup() wrongly called in PreTest/PostTest hooks

### DIFF
--- a/helpers/tdsuite/suite.go
+++ b/helpers/tdsuite/suite.go
@@ -302,17 +302,17 @@ func run(t *td.T, suite interface{}, methods []int) {
 			})
 		} else {
 			t.RunAssertRequire(m.Name, func(assert, require *td.T) {
-				if err := preTest(t, m.Name); err != nil {
-					t.Errorf("%s pre-test error: %s", m.Name, err)
+				if err := preTest(assert, m.Name); err != nil {
+					assert.Errorf("%s pre-test error: %s", m.Name, err)
 					return
 				}
 				defer func() {
-					if err := postTest(t, m.Name); err != nil {
-						t.Errorf("%s post-test error: %s", m.Name, err)
+					if err := postTest(assert, m.Name); err != nil {
+						assert.Errorf("%s post-test error: %s", m.Name, err)
 					}
 				}()
 
-				cont = shouldContinue(t, m.Name, call([]reflect.Value{
+				cont = shouldContinue(assert, m.Name, call([]reflect.Value{
 					reflect.ValueOf(assert),
 					reflect.ValueOf(require),
 				}))

--- a/helpers/tdsuite/suite_go114_test.go
+++ b/helpers/tdsuite/suite_go114_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2021, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// +build go1.14
+
+package tdsuite_test
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/helpers/tdsuite"
+	"github.com/maxatome/go-testdeep/td"
+)
+
+// FullCleanup has tests and all possible hooks.
+type FullCleanup struct{ base }
+
+func (f *FullCleanup) Setup(t *td.T) error { f.rec(); return nil }
+func (f *FullCleanup) PreTest(t *td.T, tn string) error {
+	f.rec(tn)
+	t.Cleanup(func() { f.rec(tn) })
+	return nil
+}
+func (f *FullCleanup) PostTest(t *td.T, tn string) error {
+	f.rec(tn)
+	t.Cleanup(func() { f.rec(tn) })
+	return nil
+}
+func (f *FullCleanup) BetweenTests(t *td.T, prev, next string) error {
+	f.rec(prev, next)
+	return nil
+}
+func (f *FullCleanup) Destroy(t *td.T) error { f.rec(); return nil }
+
+func (f *FullCleanup) Test1(t *td.T) {
+	f.rec()
+	t.Cleanup(func() { f.rec() })
+}
+func (f *FullCleanup) Test2(assert *td.T, require *td.T) {
+	f.rec()
+	assert.Cleanup(func() { f.rec() })
+}
+func (f *FullCleanup) Test3(t *td.T) {
+	f.rec()
+	t.Cleanup(func() { f.rec() })
+}
+func (f *FullCleanup) Testimony(t *td.T) {} // not a test method
+
+var (
+	_ tdsuite.Setup        = (*FullCleanup)(nil)
+	_ tdsuite.PreTest      = (*FullCleanup)(nil)
+	_ tdsuite.PostTest     = (*FullCleanup)(nil)
+	_ tdsuite.BetweenTests = (*FullCleanup)(nil)
+	_ tdsuite.Destroy      = (*FullCleanup)(nil)
+)
+
+func TestRunCleanup(t *testing.T) {
+	t.Run("Full", func(t *testing.T) {
+		suite := FullCleanup{}
+		td.CmpTrue(t, tdsuite.Run(t, &suite))
+		ok := td.Cmp(t, suite.calls, []string{
+			"Setup",
+			/**/ "PreTest+Test1",
+			/**/ "Test1",
+			/**/ "PostTest+Test1",
+			/**/ "PostTest.Cleanup+Test1",
+			/**/ "Test1.Cleanup",
+			/**/ "PreTest.Cleanup+Test1",
+			"BetweenTests+Test1+Test2",
+			/**/ "PreTest+Test2",
+			/**/ "Test2",
+			/**/ "PostTest+Test2",
+			/**/ "PostTest.Cleanup+Test2",
+			/**/ "Test2.Cleanup",
+			/**/ "PreTest.Cleanup+Test2",
+			"BetweenTests+Test2+Test3",
+			/**/ "PreTest+Test3",
+			/**/ "Test3",
+			/**/ "PostTest+Test3",
+			/**/ "PostTest.Cleanup+Test3",
+			/**/ "Test3.Cleanup",
+			/**/ "PreTest.Cleanup+Test3",
+			"Destroy",
+		})
+		if !ok {
+			for _, c := range suite.calls {
+				switch c[0] {
+				case 'S', 'B', 'D':
+					t.Log(c)
+				default:
+					t.Log("  ", c)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
for TestXxx(assert, require *td.T) methods.