### PR TITLE
reset test name color before newline

### DIFF
--- a/td/cmp_deeply.go
+++ b/td/cmp_deeply.go
@@ -123,13 +123,14 @@ func formatError(t TestingT, isFatal bool, err *ctxerr.Error, args ...interface{
 	var buf bytes.Buffer
 	color.AppendTestNameOn(&buf)
 	if len(args) == 0 {
-		buf.WriteString(failedTest + "\n")
+		buf.WriteString(failedTest)
 	} else {
 		buf.WriteString(failedTest + " '")
 		tdutil.FbuildTestName(&buf, args...)
-		buf.WriteString("'\n")
+		buf.WriteString("'")
 	}
 	color.AppendTestNameOff(&buf)
+	buf.WriteString("\n")
 
 	err.Append(&buf, "")
 


### PR DESCRIPTION
I'm capturing the output of "go test" (and hence go-testdeep) and prepending a string to the output. The yellow color of the test-name line leaks to the prefix of the next line.

Before this PR (see the third line):
```
⚫️ [prefix with default color] --- FAIL: TestParse (0.00s)
⚫️ [prefix with default color]    some_test.go:16: Failed test
🟡 [prefix with YELLOW color]          DATA: should NOT be an error
⚫️ [prefix with default color]                      got: (*errors.errorString)(0xc00010a780)(not implemented)
⚫️ [prefix with default color]                 expected: nil
...
```

After this PR:
```
⚫️ [prefix with default color] --- FAIL: TestParse (0.00s)
⚫️ [prefix with default color]      some_test.go:16: Failed test
⚫️ [prefix with default color]         DATA: should NOT be an error
⚫️ [prefix with default color]                      got: (*errors.errorString)(0xc00010a780)(not implemented)
⚫️ [prefix with default color]                 expected: nil
...
```

I quite like the colors of go-testdeep (fantastic readability is one of the reason I use it), so I want to keep the colors in this case.
