### PR TITLE
feat: add (*td.T).Parallel() method

### DIFF
--- a/internal/test/types.go
+++ b/internal/test/types.go
@@ -180,3 +180,25 @@ func (t *TestingTB) Skipf(format string, args ...interface{}) {}
 func (t *TestingTB) Skipped() bool {
 	return false
 }
+
+// ParallelTestingTB is a type implementing testing.TB and a Parallel() method
+// intended to be used in tests.
+type ParallelTestingTB struct {
+	IsParallel bool
+	*TestingTB
+}
+
+// NewParallelTestingTB returns a new instance of *ParallelTestingTB.
+func NewParallelTestingTB(name string) *ParallelTestingTB {
+	return &ParallelTestingTB{TestingTB: NewTestingTB(name)}
+}
+
+// Parallel mocks the testing.T Parallel method. Not thread-safe.
+func (t *ParallelTestingTB) Parallel() {
+	if t.IsParallel {
+		// testing.T.Parallel() panics if called multiple times for the
+		// same test.
+		panic("testing: t.Parallel called multiple times")
+	}
+	t.IsParallel = true
+}

--- a/td/t_struct.go
+++ b/td/t_struct.go
@@ -471,6 +471,28 @@ func (t *T) CmpNotPanic(fn func(), args ...interface{}) bool {
 	return cmpNotPanic(newContextWithConfig(t.Config), t, fn, args...)
 }
 
+// Parallel marks this test as runnable in parallel with other parallel tests.
+// If t.TB implements Parallel(), as *testing.T does, it is usually used to
+// mark top-level tests and/or subtests as safe for parallel execution:
+//
+//   func TestCreateRecord(tt *testing.T) {
+//     t := td.NewT(tt)
+//     t.Parallel()
+//
+//     t.Run("no error", func(t *td.T) {
+//       t.Parallel()
+//
+//       // ...
+//     })
+//
+// If t.TB does not implement Parallel(), this method is a no-op.
+func (t *T) Parallel() {
+	p, ok := t.TB.(interface{ Parallel() })
+	if ok {
+		p.Parallel()
+	}
+}
+
 type runtFuncs struct {
 	run reflect.Value
 	fnt reflect.Type


### PR DESCRIPTION
Add a Parallel() method to `*td.T` that calls `Parallel()` on the
underlying `testing.TB` if it supports the method. This will have no
effect on `*testing.B` or custom wrappers that do not support
`Parallel()`.

Per #149, this implements this as a method rather than a top-level
`td.Parallel(t)` function because this is closer to what existing usage
of `*testing.T` looks like.

Resolves #149
