### PR TITLE
feat: add IgnoreUnexported feature and rework UseEqual

### DIFF
--- a/internal/ctxerr/context.go
+++ b/internal/ctxerr/context.go
@@ -39,6 +39,8 @@ type Context struct {
 	UseEqual bool
 	// See ContextConfig.BeLax for details.
 	BeLax bool
+	// See ContextConfig.IgnoreUnexported for details.
+	IgnoreUnexported bool
 }
 
 // InitErrors initializes Context *Errors slice, if MaxErrors < 0 or

--- a/td/equal_test.go
+++ b/td/equal_test.go
@@ -308,6 +308,41 @@ func TestEqualStruct(t *testing.T) {
 			Got:      mustBe("int"),
 			Expected: mustBe("string"),
 		})
+
+	type SType struct {
+		Public  int
+		private string
+	}
+
+	checkOK(t,
+		SType{Public: 42, private: "test"},
+		SType{Public: 42, private: "test"})
+
+	checkError(t,
+		SType{Public: 42, private: "test"},
+		SType{Public: 42},
+		expectedError{
+			Message:  mustBe("values differ"),
+			Path:     mustBe("DATA.private"),
+			Got:      mustBe(`"test"`),
+			Expected: mustBe(`""`),
+		})
+
+	defer func() { td.DefaultContextConfig.IgnoreUnexported = false }()
+	td.DefaultContextConfig.IgnoreUnexported = true
+
+	checkOK(t,
+		SType{Public: 42, private: "test"},
+		SType{Public: 42})
+
+	// Be careful with structs containing only private fields
+	checkOK(t,
+		ItemProperty{
+			name:  "foo",
+			kind:  12,
+			value: "bar",
+		},
+		ItemProperty{})
 }
 
 //


### PR DESCRIPTION
IgnoreUnexported & UseEqual can now be scoped to some types.