### PR TITLE
feat: introduce nocolor helper

### DIFF
--- a/helpers/nocolor/nocolor.go
+++ b/helpers/nocolor/nocolor.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Package nocolor is only intended to easily disable coloring output
+// of failure reports, typically useful in golang playground.
+//
+// Simply import it, and nothing else:
+//
+//   import _ "github.com/maxatome/go-testdeep/td/helpers/nocolor"
+package nocolor
+
+import "os"
+
+func init() {
+	os.Setenv("TESTDEEP_COLOR", "off")
+}

--- a/helpers/nocolor/nocolor_test.go
+++ b/helpers/nocolor/nocolor_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package nocolor_test
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/maxatome/go-testdeep/helpers/nocolor"
+)
+
+func TestNocolor(t *testing.T) {
+	tdColor := os.Getenv("TESTDEEP_COLOR")
+	if tdColor != "off" {
+		t.Errorf(`TESTDEEP_COLOR expected to be "off" but is %q`, tdColor)
+	}
+}


### PR DESCRIPTION
to easily disable coloring output of failure reports, typically useful in golang playground.