### PR TITLE
feat(tdhttp): add CmpCookies

### DIFF
--- a/helpers/tdhttp/doc.go
+++ b/helpers/tdhttp/doc.go
@@ -19,6 +19,7 @@
 //   ta.Get("/person/42", "Accept", "application/xml").
 //     CmpStatus(http.StatusOK).
 //     CmpHeader(td.ContainsKey("X-Custom-Header")).
+//     CmpCookie(td.SuperBagOf(td.Smuggle("Name", "cookie_session"))).
 //     CmpXMLBody(Person{
 //       ID:   ta.Anchor(td.NotZero(), uint64(0)).(uint64),
 //       Name: "Bob",
@@ -27,7 +28,8 @@
 //
 //   ta.Get("/person/42", "Accept", "application/json").
 //     CmpStatus(http.StatusOK).
-//     CmpHeader(td.ContainsKey("X-Custom-Header")).
+//     CmpHeaders(td.ContainsKey("X-Custom-Header")).
+//     CmpCookies(td.SuperBagOf(td.Struct(&http.Cookie{Name: "cookie_session"}, nil))).
 //     CmpJSONBody(td.JSON(`
 //   {
 //     "id":   $1,

--- a/helpers/tdhttp/http.go
+++ b/helpers/tdhttp/http.go
@@ -27,9 +27,10 @@ func init() {
 // response match easier. Each field, can be a TestDeep operator as
 // well as the exact expected value.
 type Response struct {
-	Status interface{} // Status is the expected status (ignored if nil)
-	Header interface{} // Header is the expected header (ignored if nil)
-	Body   interface{} // Body is the expected body (expected to be empty if nil)
+	Status  interface{} // Status is the expected status (ignored if nil)
+	Header  interface{} // Header is the expected header (ignored if nil)
+	Cookies interface{} // Cookies are the expected cookies (ignored if nil)
+	Body    interface{} // Body is the expected body (expected to be empty if nil)
 }
 
 func cmpMarshaledResponse(tb testing.TB,
@@ -59,6 +60,11 @@ func cmpMarshaledResponse(tb testing.TB,
 	// Check header, nil = ignore
 	if expectedResp.Header != nil {
 		ta.CmpHeader(expectedResp.Header)
+	}
+
+	// Check cookie, nil = ignore
+	if expectedResp.Cookies != nil {
+		ta.CmpCookies(expectedResp.Cookies)
 	}
 
 	if expectedResp.Body == nil {


### PR DESCRIPTION
```bash
julien@julien-VirtualBox:~/git/go-testdeep$ go test ./... -cover
ok      github.com/maxatome/go-testdeep 0.038s  coverage: [no statements]
ok      github.com/maxatome/go-testdeep/helpers/nocolor 0.047s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/helpers/tdhttp  0.075s  coverage: 99.4% of statements
ok      github.com/maxatome/go-testdeep/helpers/tdhttp/internal 0.017s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/helpers/tdsuite 0.019s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/helpers/tdutil  0.004s  coverage: 99.4% of statements
ok      github.com/maxatome/go-testdeep/internal/anchors        0.022s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/color  0.011s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/ctxerr 0.007s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/dark   0.003s  coverage: 95.6% of statements
ok      github.com/maxatome/go-testdeep/internal/flat   0.011s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/hooks  0.009s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/json   0.006s  coverage: 91.6% of statements
?       github.com/maxatome/go-testdeep/internal/location       [no test files]
?       github.com/maxatome/go-testdeep/internal/test   [no test files]
ok      github.com/maxatome/go-testdeep/internal/trace  0.005s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/types  0.008s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/util   0.016s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/internal/visited        0.007s  coverage: 100.0% of statements
ok      github.com/maxatome/go-testdeep/td      0.209s  coverage: 99.8% of statements
```