### PR TITLE
fix(Len/Cap): Len & Cap could not be used in JSON

### DIFF
--- a/td/td_json_test.go
+++ b/td/td_json_test.go
@@ -120,6 +120,9 @@ func TestJSON(t *testing.T) {
 			td.Tag("age", td.Between(40, 45)),
 			td.Tag("name", td.Re(`^Bob`))))
 
+	// Len
+	checkOK(t, []int{1, 2, 3}, td.JSON(`Len(3)`))
+
 	//
 	// []byte
 	checkOK(t, got,

--- a/td/td_len_cap_test.go
+++ b/td/td_len_cap_test.go
@@ -7,6 +7,7 @@
 package td_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/internal/test"
@@ -22,6 +23,17 @@ func TestLen(t *testing.T) {
 	checkOK(t, []byte("abcd"), td.Len(td.Between(4, 6)))
 
 	checkOK(t, [5]int{}, td.Len(5))
+	checkOK(t, [5]int{}, td.Len(int8(5)))
+	checkOK(t, [5]int{}, td.Len(int16(5)))
+	checkOK(t, [5]int{}, td.Len(int32(5)))
+	checkOK(t, [5]int{}, td.Len(int64(5)))
+	checkOK(t, [5]int{}, td.Len(uint(5)))
+	checkOK(t, [5]int{}, td.Len(uint8(5)))
+	checkOK(t, [5]int{}, td.Len(uint16(5)))
+	checkOK(t, [5]int{}, td.Len(uint32(5)))
+	checkOK(t, [5]int{}, td.Len(uint64(5)))
+	checkOK(t, [5]int{}, td.Len(float32(5)))
+	checkOK(t, [5]int{}, td.Len(float64(5)))
 	checkOK(t, [5]int{}, td.Len(td.Between(4, 6)))
 
 	checkOK(t, map[int]bool{1: true, 2: false}, td.Len(2))
@@ -57,11 +69,52 @@ func TestLen(t *testing.T) {
 	//
 	// Bad usage
 	checkError(t, "never tested",
-		td.Len(int64(12)),
+		td.Len(nil),
 		expectedError{
 			Message: mustBe("Bad usage of Len operator"),
 			Path:    mustBe("DATA"),
-			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received int64 as 1st parameter"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received nil as 1st parameter"),
+		})
+
+	checkError(t, "never tested",
+		td.Len("12"),
+		expectedError{
+			Message: mustBe("Bad usage of Len operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received string as 1st parameter"),
+		})
+
+	// out of bounds
+	checkError(t, "never tested",
+		td.Len(uint64(math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Len operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (18446744073709551615), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Len(float64(math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Len operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (1.8446744073709552e+19), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Len(float64(-math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Len operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (-1.8446744073709552e+19), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Len(3.1),
+		expectedError{
+			Message: mustBe("Bad usage of Len operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Len(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (3.1), should be in int range"),
 		})
 
 	//
@@ -72,7 +125,7 @@ func TestLen(t *testing.T) {
 	test.EqualStr(t, td.Len(td.Gt(8)).String(), "len: > 8")
 
 	// Erroneous
-	test.EqualStr(t, td.Len(int64(12)).String(), "Len(<ERROR>)")
+	test.EqualStr(t, td.Len("12").String(), "Len(<ERROR>)")
 }
 
 func TestCap(t *testing.T) {
@@ -80,6 +133,17 @@ func TestCap(t *testing.T) {
 	checkOK(t, make([]byte, 0, 4), td.Cap(td.Between(4, 6)))
 
 	checkOK(t, [5]int{}, td.Cap(5))
+	checkOK(t, [5]int{}, td.Cap(int8(5)))
+	checkOK(t, [5]int{}, td.Cap(int16(5)))
+	checkOK(t, [5]int{}, td.Cap(int32(5)))
+	checkOK(t, [5]int{}, td.Cap(int64(5)))
+	checkOK(t, [5]int{}, td.Cap(uint(5)))
+	checkOK(t, [5]int{}, td.Cap(uint8(5)))
+	checkOK(t, [5]int{}, td.Cap(uint16(5)))
+	checkOK(t, [5]int{}, td.Cap(uint32(5)))
+	checkOK(t, [5]int{}, td.Cap(uint64(5)))
+	checkOK(t, [5]int{}, td.Cap(float32(5)))
+	checkOK(t, [5]int{}, td.Cap(float64(5)))
 	checkOK(t, [5]int{}, td.Cap(td.Between(4, 6)))
 
 	checkOK(t, make(chan int, 3), td.Cap(3))
@@ -111,11 +175,52 @@ func TestCap(t *testing.T) {
 	//
 	// Bad usage
 	checkError(t, "never tested",
-		td.Cap(int64(12)),
+		td.Cap(nil),
 		expectedError{
 			Message: mustBe("Bad usage of Cap operator"),
 			Path:    mustBe("DATA"),
-			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received int64 as 1st parameter"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received nil as 1st parameter"),
+		})
+
+	checkError(t, "never tested",
+		td.Cap("12"),
+		expectedError{
+			Message: mustBe("Bad usage of Cap operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received string as 1st parameter"),
+		})
+
+	// out of bounds
+	checkError(t, "never tested",
+		td.Cap(uint64(math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Cap operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (18446744073709551615), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Cap(float64(math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Cap operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (1.8446744073709552e+19), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Cap(float64(-math.MaxUint64)),
+		expectedError{
+			Message: mustBe("Bad usage of Cap operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (-1.8446744073709552e+19), should be in int range"),
+		})
+
+	checkError(t, "never tested",
+		td.Cap(3.1),
+		expectedError{
+			Message: mustBe("Bad usage of Cap operator"),
+			Path:    mustBe("DATA"),
+			Summary: mustBe("usage: Cap(TESTDEEP_OPERATOR|INT), but received an out of bounds or not integer 1st parameter (3.1), should be in int range"),
 		})
 
 	//
@@ -126,7 +231,7 @@ func TestCap(t *testing.T) {
 	test.EqualStr(t, td.Cap(td.Gt(8)).String(), "cap: > 8")
 
 	// Erroneous op
-	test.EqualStr(t, td.Cap(int64(12)).String(), "Cap(<ERROR>)")
+	test.EqualStr(t, td.Cap("12").String(), "Cap(<ERROR>)")
 }
 
 func TestLenCapTypeBehind(t *testing.T) {
@@ -134,6 +239,6 @@ func TestLenCapTypeBehind(t *testing.T) {
 	equalTypes(t, td.Len(3), nil)
 
 	// Erroneous op
-	equalTypes(t, td.Cap(int64(12)), nil)
-	equalTypes(t, td.Len(int64(12)), nil)
+	equalTypes(t, td.Cap("12"), nil)
+	equalTypes(t, td.Len("12"), nil)
 }


### PR DESCRIPTION
because JSON uses float64 and Len/Cap expected int.

Len and Cap now accept any number type, not only int as before.