### PR TITLE
feat(JSON): rework placeholders handling

### DIFF
--- a/td/example_t_test.go
+++ b/td/example_t_test.go
@@ -948,10 +948,13 @@ func ExampleT_JSON_basic() {
 func ExampleT_JSON_placeholders() {
 	t := td.NewT(&testing.T{})
 
-	got := &struct {
-		Fullname string `json:"fullname"`
-		Age      int    `json:"age"`
-	}{
+	type Person struct {
+		Fullname string    `json:"fullname"`
+		Age      int       `json:"age"`
+		Children []*Person `json:"children,omitempty"`
+	}
+
+	got := &Person{
 		Fullname: "Bob Foobar",
 		Age:      42,
 	}
@@ -968,11 +971,22 @@ func ExampleT_JSON_placeholders() {
 	ok = t.JSON(got, `{"age": $age, "fullname": $name}`, []interface{}{td.Tag("age", td.Between(40, 45)), td.Tag("name", td.HasSuffix("Foobar"))})
 	fmt.Println("check got with named placeholders:", ok)
 
+	got.Children = []*Person{
+		{Fullname: "Alice", Age: 28},
+		{Fullname: "Brian", Age: 22},
+	}
+	ok = t.JSON(got, `{"age": $age, "fullname": $name, "children": $children}`, []interface{}{td.Tag("age", td.Between(40, 45)), td.Tag("name", td.HasSuffix("Foobar")), td.Tag("children", td.Bag(
+		&Person{Fullname: "Brian", Age: 22},
+		&Person{Fullname: "Alice", Age: 28},
+	))})
+	fmt.Println("check got w/named placeholders, and children w/go structs:", ok)
+
 	// Output:
 	// check got with numeric placeholders without operators: true
 	// check got with numeric placeholders: true
 	// check got with double-quoted numeric placeholders: true
 	// check got with named placeholders: true
+	// check got w/named placeholders, and children w/go structs: true
 }
 
 func ExampleT_JSON_embedding() {

--- a/td/example_test.go
+++ b/td/example_test.go
@@ -1053,10 +1053,13 @@ func ExampleJSON_basic() {
 func ExampleJSON_placeholders() {
 	t := &testing.T{}
 
-	got := &struct {
-		Fullname string `json:"fullname"`
-		Age      int    `json:"age"`
-	}{
+	type Person struct {
+		Fullname string    `json:"fullname"`
+		Age      int       `json:"age"`
+		Children []*Person `json:"children,omitempty"`
+	}
+
+	got := &Person{
 		Fullname: "Bob Foobar",
 		Age:      42,
 	}
@@ -1082,11 +1085,26 @@ func ExampleJSON_placeholders() {
 			td.Tag("name", td.HasSuffix("Foobar"))))
 	fmt.Println("check got with named placeholders:", ok)
 
+	got.Children = []*Person{
+		{Fullname: "Alice", Age: 28},
+		{Fullname: "Brian", Age: 22},
+	}
+	ok = td.Cmp(t, got,
+		td.JSON(`{"age": $age, "fullname": $name, "children": $children}`,
+			td.Tag("age", td.Between(40, 45)),
+			td.Tag("name", td.HasSuffix("Foobar")),
+			td.Tag("children", td.Bag(
+				&Person{Fullname: "Brian", Age: 22},
+				&Person{Fullname: "Alice", Age: 28},
+			))))
+	fmt.Println("check got w/named placeholders, and children w/go structs:", ok)
+
 	// Output:
 	// check got with numeric placeholders without operators: true
 	// check got with numeric placeholders: true
 	// check got with double-quoted numeric placeholders: true
 	// check got with named placeholders: true
+	// check got w/named placeholders, and children w/go structs: true
 }
 
 func ExampleJSON_embedding() {

--- a/td/types_test.go
+++ b/td/types_test.go
@@ -6,11 +6,14 @@
 
 // Work around https://github.com/golang/go/issues/26995 issue
 // (corrected in go 1.12).
+//go:build go1.12
 // +build go1.12
 
 package td_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/helpers/tdutil"
@@ -108,4 +111,13 @@ func TestSetlocation(t *testing.T) {
 func TestError(t *testing.T) {
 	test.NoError(t, td.Re(`x`).Error())
 	test.Error(t, td.Re(123).Error())
+}
+
+func TestMarshalJSON(t *testing.T) {
+	op := td.String("foo")
+
+	_, err := json.Marshal(op)
+	if test.Error(t, err) {
+		test.IsTrue(t, strings.HasSuffix(err.Error(), "String TestDeep operator cannot be json.Marshal'led"))
+	}
 }

--- a/tools/gen_funcs.pl
+++ b/tools/gen_funcs.pl
@@ -205,7 +205,7 @@ while (readdir $dh)
                 . join(', ', keys %inputs) . "\n";
         }
 
-        if ($contents =~ /^\ttdSmugglerBase/m
+        if ($contents =~ m,^\ttdSmugglerBase(?! // ignored),m
             and $num_smugglers == keys %SMUGGLER_OPERATORS)
         {
             die "$_: this file should contain at least one smuggler operator\n";


### PR DESCRIPTION
JSON, SubJSONOf & SuperJSONOf adopt the same behavior as JSONPointer
for their placeholders. Got value is JSON marshalled then unmarshalled
in a new value matching the placeholder type.