### PR TITLE
fix(JSON): same behavior for embedded & placeholder operators

### DIFF
--- a/td/example_cmp_test.go
+++ b/td/example_cmp_test.go
@@ -981,12 +981,16 @@ func ExampleCmpJSON_placeholders() {
 	))})
 	fmt.Println("check got w/named placeholders, and children w/go structs:", ok)
 
+	ok = td.CmpJSON(t, got, `{"age": Between($1, $2), "fullname": HasSuffix($suffix), "children": Len(2)}`, []interface{}{40, 45, td.Tag("suffix", "Foobar")})
+	fmt.Println("check got w/num & named placeholders:", ok)
+
 	// Output:
 	// check got with numeric placeholders without operators: true
 	// check got with numeric placeholders: true
 	// check got with double-quoted numeric placeholders: true
 	// check got with named placeholders: true
 	// check got w/named placeholders, and children w/go structs: true
+	// check got w/num & named placeholders: true
 }
 
 func ExampleCmpJSON_embedding() {
@@ -1026,11 +1030,22 @@ func ExampleCmpJSON_embedding() {
 }`, nil)
 	fmt.Println("check got with complex operators:", ok)
 
+	ok = td.CmpJSON(t, got, `
+{
+  "age":      Between($1, $2, $3), // in ]40; 42]
+  "fullname": All(
+    HasPrefix($4),
+    HasSuffix("bar")  // ← comma is optional here
+  )
+}`, []interface{}{40, 42, td.BoundsOutIn, "Bob"})
+	fmt.Println("check got with complex operators, w/placeholder args:", ok)
+
 	// Output:
 	// check got with simple operators: true
 	// check got with operator shortcuts: true
 	// check got with complex operators: true
 	// check got with complex operators: false
+	// check got with complex operators, w/placeholder args: true
 }
 
 func ExampleCmpJSON_file() {

--- a/td/example_t_test.go
+++ b/td/example_t_test.go
@@ -981,12 +981,16 @@ func ExampleT_JSON_placeholders() {
 	))})
 	fmt.Println("check got w/named placeholders, and children w/go structs:", ok)
 
+	ok = t.JSON(got, `{"age": Between($1, $2), "fullname": HasSuffix($suffix), "children": Len(2)}`, []interface{}{40, 45, td.Tag("suffix", "Foobar")})
+	fmt.Println("check got w/num & named placeholders:", ok)
+
 	// Output:
 	// check got with numeric placeholders without operators: true
 	// check got with numeric placeholders: true
 	// check got with double-quoted numeric placeholders: true
 	// check got with named placeholders: true
 	// check got w/named placeholders, and children w/go structs: true
+	// check got w/num & named placeholders: true
 }
 
 func ExampleT_JSON_embedding() {
@@ -1026,11 +1030,22 @@ func ExampleT_JSON_embedding() {
 }`, nil)
 	fmt.Println("check got with complex operators:", ok)
 
+	ok = t.JSON(got, `
+{
+  "age":      Between($1, $2, $3), // in ]40; 42]
+  "fullname": All(
+    HasPrefix($4),
+    HasSuffix("bar")  // ← comma is optional here
+  )
+}`, []interface{}{40, 42, td.BoundsOutIn, "Bob"})
+	fmt.Println("check got with complex operators, w/placeholder args:", ok)
+
 	// Output:
 	// check got with simple operators: true
 	// check got with operator shortcuts: true
 	// check got with complex operators: true
 	// check got with complex operators: false
+	// check got with complex operators, w/placeholder args: true
 }
 
 func ExampleT_JSON_file() {

--- a/td/example_test.go
+++ b/td/example_test.go
@@ -1099,12 +1099,19 @@ func ExampleJSON_placeholders() {
 			))))
 	fmt.Println("check got w/named placeholders, and children w/go structs:", ok)
 
+	ok = td.Cmp(t, got,
+		td.JSON(`{"age": Between($1, $2), "fullname": HasSuffix($suffix), "children": Len(2)}`,
+			40, 45,
+			td.Tag("suffix", "Foobar")))
+	fmt.Println("check got w/num & named placeholders:", ok)
+
 	// Output:
 	// check got with numeric placeholders without operators: true
 	// check got with numeric placeholders: true
 	// check got with double-quoted numeric placeholders: true
 	// check got with named placeholders: true
 	// check got w/named placeholders, and children w/go structs: true
+	// check got w/num & named placeholders: true
 }
 
 func ExampleJSON_embedding() {
@@ -1144,11 +1151,24 @@ func ExampleJSON_embedding() {
 }`))
 	fmt.Println("check got with complex operators:", ok)
 
+	ok = td.Cmp(t, got, td.JSON(`
+{
+  "age":      Between($1, $2, $3), // in ]40; 42]
+  "fullname": All(
+    HasPrefix($4),
+    HasSuffix("bar")  // ← comma is optional here
+  )
+}`,
+		40, 42, td.BoundsOutIn,
+		"Bob"))
+	fmt.Println("check got with complex operators, w/placeholder args:", ok)
+
 	// Output:
 	// check got with simple operators: true
 	// check got with operator shortcuts: true
 	// check got with complex operators: true
 	// check got with complex operators: false
+	// check got with complex operators, w/placeholder args: true
 }
 
 func ExampleJSON_file() {


### PR DESCRIPTION
Now:

    td.JSON(`{"foo": $1}`, td.Between(12, 34))
    td.JSON(`{"foo": Between($1, $2)}`, 12, 34)

act the same way. Since v1.10.1 rework, the second was not working as
expected.

At the same time:

    td.JSON(`{"foo": Between(12, 34, $1)}`, td.BoundsOutIn)

now works as expected. It was rejected before.