### PR TITLE
feat(JSON): accept int_lit & float_lit numbers as defined in go spec

### DIFF
--- a/internal/json/parser_go113_test.go
+++ b/internal/json/parser_go113_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2022, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.13
+// +build go1.13
+
+package json_test
+
+import (
+	"testing"
+)
+
+func TestJSON_go113(t *testing.T) {
+	// Extend to golang 1.13 accepted numbers
+
+	// as int64
+	checkJSON(t, `4_2`, `42`)
+	checkJSON(t, `+4_2`, `42`)
+	checkJSON(t, `-4_2`, `-42`)
+
+	checkJSON(t, `0b101010`, `42`)
+	checkJSON(t, `-0b101010`, `-42`)
+	checkJSON(t, `+0b101010`, `42`)
+
+	checkJSON(t, `0b10_1010`, `42`)
+	checkJSON(t, `-0b_10_1010`, `-42`)
+	checkJSON(t, `+0b10_10_10`, `42`)
+
+	checkJSON(t, `0B101010`, `42`)
+	checkJSON(t, `-0B101010`, `-42`)
+	checkJSON(t, `+0B101010`, `42`)
+
+	checkJSON(t, `0B10_1010`, `42`)
+	checkJSON(t, `-0B_10_1010`, `-42`)
+	checkJSON(t, `+0B10_10_10`, `42`)
+
+	checkJSON(t, `0_600`, `384`)
+	checkJSON(t, `-0_600`, `-384`)
+	checkJSON(t, `+0_600`, `384`)
+
+	checkJSON(t, `0o600`, `384`)
+	checkJSON(t, `0o_600`, `384`)
+	checkJSON(t, `-0o600`, `-384`)
+	checkJSON(t, `-0o6_00`, `-384`)
+	checkJSON(t, `+0o600`, `384`)
+	checkJSON(t, `+0o60_0`, `384`)
+
+	checkJSON(t, `0O600`, `384`)
+	checkJSON(t, `0O_600`, `384`)
+	checkJSON(t, `-0O600`, `-384`)
+	checkJSON(t, `-0O6_00`, `-384`)
+	checkJSON(t, `+0O600`, `384`)
+	checkJSON(t, `+0O60_0`, `384`)
+
+	checkJSON(t, `0xBad_Face`, `195951310`)
+	checkJSON(t, `-0x_Bad_Face`, `-195951310`)
+	checkJSON(t, `+0xBad_Face`, `195951310`)
+
+	checkJSON(t, `0XBad_Face`, `195951310`)
+	checkJSON(t, `-0X_Bad_Face`, `-195951310`)
+	checkJSON(t, `+0XBad_Face`, `195951310`)
+
+	// as float64
+	checkJSON(t, `0_600.123`, `600.123`) // float64 can not be an octal number
+	checkJSON(t, `1_5.`, `15`)
+	checkJSON(t, `0.15e+0_2`, `15`)
+	checkJSON(t, `0x1p-2`, `0.25`)
+	checkJSON(t, `0x2.p10`, `2048`)
+	checkJSON(t, `0x1.Fp+0`, `1.9375`)
+	checkJSON(t, `0X.8p-0`, `0.5`)
+	checkJSON(t, `0X_1FFFP-16`, `0.1249847412109375`)
+}

--- a/td/td_json.go
+++ b/td/td_json.go
@@ -581,6 +581,11 @@ func jsonify(ctx ctxerr.Context, got reflect.Value) (interface{}, *ctxerr.Error)
 //   - multi-lines comments start with the character sequence /* and stop
 //     with the first subsequent character sequence */.
 //
+// Other JSON divergences:
+//   - ',' can precede a '}' or a ']' (as in go);
+//   - int_lit & float_lit numbers as defined in go spec are accepted;
+//   - numbers can be prefixed by '+'.
+//
 // Most operators can be directly embedded in JSON without requiring
 // any placeholder.
 //
@@ -841,6 +846,11 @@ var _ TestDeep = &tdMapJSON{}
 //   - multi-lines comments start with the character sequence /* and stop
 //     with the first subsequent character sequence */.
 //
+// Other JSON divergences:
+//   - ',' can precede a '}' or a ']' (as in go);
+//   - int_lit & float_lit numbers as defined in go spec are accepted;
+//   - numbers can be prefixed by '+'.
+//
 // Most operators can be directly embedded in SubJSONOf without requiring
 // any placeholder.
 //
@@ -1054,6 +1064,11 @@ func SubJSONOf(expectedJSON interface{}, params ...interface{}) TestDeep {
 //     end of the line.
 //   - multi-lines comments start with the character sequence /* and stop
 //     with the first subsequent character sequence */.
+//
+// Other JSON divergences:
+//   - ',' can precede a '}' or a ']' (as in go);
+//   - int_lit & float_lit numbers as defined in go spec are accepted;
+//   - numbers can be prefixed by '+'.
 //
 // Most operators can be directly embedded in SuperJSONOf without requiring
 // any placeholder.


### PR DESCRIPTION
The following numbers are now accepted by JSON, SuperJSONOf and
SubJSONOf operators:
```
    +42          → 42
    4_2          → 42
    0b101010     → 42
    0b10_1010    → 42
    0600         → 384
    0_600        → 384
    0o600        → 384
    0O600        → 384 // second character is capital letter 'O'
    0xBadFace    → 195951310
    0x_Bad_Face  → 195951310
    .25          → 0.25
    1_5.         → 15.0
    0.15e+0_2    → 15.0
    0x1p-2       → 0.25
    0x2.p10      → 2048.0
    0x1.Fp+0     → 1.9375
    0X.8p-0      → 0.5
    0X_1FFFP-16  → 0.1249847412109375
```