### PR TITLE
ci: add asciicheck & durationcheck linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
           echo $PATH
           $HOME/go/bin/golangci-lint run --max-issues-per-linter 0 \
                                          --max-same-issues 0 \
+                                         -E asciicheck \
                                          -E bidichk \
+                                         -E durationcheck \
                                          -E exportloopref \
                                          -E gocritic \
                                          -E godot \

--- a/helpers/tdsuite/suite_go114_test.go
+++ b/helpers/tdsuite/suite_go114_test.go
@@ -25,11 +25,13 @@ func (f *FullCleanup) PreTest(t *td.T, tn string) error {
 	t.Cleanup(func() { f.rec(tn) })
 	return nil
 }
+
 func (f *FullCleanup) PostTest(t *td.T, tn string) error {
 	f.rec(tn)
 	t.Cleanup(func() { f.rec(tn) })
 	return nil
 }
+
 func (f *FullCleanup) BetweenTests(t *td.T, prev, next string) error {
 	f.rec(prev, next)
 	return nil
@@ -40,10 +42,12 @@ func (f *FullCleanup) Test1(t *td.T) {
 	f.rec()
 	t.Cleanup(func() { f.rec() })
 }
+
 func (f *FullCleanup) Test2(assert *td.T, require *td.T) {
 	f.rec()
 	assert.Cleanup(func() { f.rec() })
 }
+
 func (f *FullCleanup) Test3(t *td.T) {
 	f.rec()
 	t.Cleanup(func() { f.rec() })

--- a/helpers/tdsuite/suite_test.go
+++ b/helpers/tdsuite/suite_test.go
@@ -342,6 +342,7 @@ func (e *Error) Setup(t *td.T) error {
 	}
 	return nil
 }
+
 func (e *Error) PreTest(t *td.T, tn string) error {
 	if e.preTest > 0 {
 		e.preTest--
@@ -351,6 +352,7 @@ func (e *Error) PreTest(t *td.T, tn string) error {
 	}
 	return nil
 }
+
 func (e *Error) PostTest(t *td.T, tn string) error {
 	if e.postTest > 0 {
 		e.postTest--
@@ -360,12 +362,14 @@ func (e *Error) PostTest(t *td.T, tn string) error {
 	}
 	return nil
 }
+
 func (e *Error) BetweenTests(t *td.T, prev, next string) error {
 	if e.betweenTests {
 		return errors.New("BetweenTests error")
 	}
 	return nil
 }
+
 func (e *Error) Destroy(t *td.T) error {
 	if e.destroy {
 		return errors.New("Destroy error")
@@ -378,6 +382,7 @@ func (e *Error) Test1Bool(t *td.T) bool {
 	e.rec()
 	return !e.testBool[0]
 }
+
 func (e *Error) Test1Error(t *td.T) error {
 	e.rec()
 	if e.testError[0] {
@@ -385,6 +390,7 @@ func (e *Error) Test1Error(t *td.T) error {
 	}
 	return nil
 }
+
 func (e *Error) Test1BoolError(t *td.T) (b bool, err error) {
 	e.rec()
 	b = !e.testBoolErrorBool[0]
@@ -400,6 +406,7 @@ func (e *Error) Test2Bool(assert, require *td.T) bool {
 	e.rec()
 	return !e.testBool[1]
 }
+
 func (e *Error) Test2Error(assert, require *td.T) error {
 	e.rec()
 	if e.testError[1] {
@@ -407,6 +414,7 @@ func (e *Error) Test2Error(assert, require *td.T) error {
 	}
 	return nil
 }
+
 func (e *Error) Test2BoolError(assert, require *td.T) (b bool, err error) {
 	e.rec()
 	b = !e.testBoolErrorBool[1]

--- a/internal/anchors/anchor_test.go
+++ b/internal/anchors/anchor_test.go
@@ -79,7 +79,7 @@ func TestBuildResolveAnchor(t *testing.T) {
 	})
 
 	t.Run("AddAnchor", func(t *testing.T) {
-		var oldAnchorableTypes = anchors.AnchorableTypes
+		oldAnchorableTypes := anchors.AnchorableTypes
 		defer func() { anchors.AnchorableTypes = oldAnchorableTypes }()
 
 		type ok struct{ index int }

--- a/internal/anchors/types_test.go
+++ b/internal/anchors/types_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAddAnchorableStructType(t *testing.T) {
-	var oldAnchorableTypes = anchors.AnchorableTypes
+	oldAnchorableTypes := anchors.AnchorableTypes
 	defer func() { anchors.AnchorableTypes = oldAnchorableTypes }()
 
 	type ok struct{ index int }

--- a/internal/util/string_test.go
+++ b/internal/util/string_test.go
@@ -43,9 +43,11 @@ func TestToString(t *testing.T) {
 		{paramGot: "foo\n`\"bar", expected: "(string) (len=9) \"foo\\n`\\\"bar\""},
 		{paramGot: "foo\n\"`bar", expected: "(string) (len=9) \"foo\\n\\\"`bar\""},
 		{paramGot: reflect.ValueOf("foobar"), expected: `"foobar"`},
-		{paramGot: []reflect.Value{reflect.ValueOf("foo"), reflect.ValueOf("bar")},
+		{
+			paramGot: []reflect.Value{reflect.ValueOf("foo"), reflect.ValueOf("bar")},
 			expected: `("foo",
- "bar")`},
+ "bar")`,
+		},
 		{paramGot: types.RawString("test"), expected: "test"},
 		{paramGot: types.RawInt(42), expected: "42"},
 		{paramGot: myTestDeepStringer{}, expected: "TesT!"},

--- a/td/example_test.go
+++ b/td/example_test.go
@@ -2767,10 +2767,10 @@ func ExampleSmuggle_complex() {
 	// Checks that end date is between 17th and 19th February both at 0h
 	// for each of these durations in hours
 
-	for _, duration := range []time.Duration{48, 72, 96} {
+	for _, duration := range []time.Duration{48 * time.Hour, 72 * time.Hour, 96 * time.Hour} {
 		got := StartDuration{
 			StartDate: time.Date(2018, time.February, 14, 12, 13, 14, 0, time.UTC),
-			Duration:  duration * time.Hour,
+			Duration:  duration,
 		}
 
 		// Simplest way, but in case of Between() failure, error will be bound

--- a/td/td_isa_test.go
+++ b/td/td_isa_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestIsa(t *testing.T) {
-	var gotStruct = MyStruct{
+	gotStruct := MyStruct{
 		MyStructMid: MyStructMid{
 			MyStructBase: MyStructBase{
 				ValBool: true,

--- a/td/td_json.go
+++ b/td/td_json.go
@@ -162,7 +162,6 @@ func (u tdJSONUnmarshaler) unmarshal(expectedJSON interface{}, params []interfac
 		OpShortcutFn:       u.resolveOpShortcut(),
 		OpFn:               u.resolveOp(),
 	})
-
 	if err != nil {
 		return nil, ctxerr.OpBad(u.Func, "JSON unmarshal error: %s", err)
 	}

--- a/td/td_struct_test.go
+++ b/td/td_struct_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestStruct(t *testing.T) {
-	var gotStruct = MyStruct{
+	gotStruct := MyStruct{
 		MyStructMid: MyStructMid{
 			MyStructBase: MyStructBase{
 				ValBool: true,
@@ -703,7 +703,7 @@ func TestStructTypeBehind(t *testing.T) {
 }
 
 func TestSStruct(t *testing.T) {
-	var gotStruct = MyStruct{
+	gotStruct := MyStruct{
 		MyStructMid: MyStructMid{
 			MyStructBase: MyStructBase{
 				ValBool: true,

--- a/td/td_trunc_time_test.go
+++ b/td/td_trunc_time_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/maxatome/go-testdeep/td"
 )
 
-type MyTime time.Time
-type MyTimeStr time.Time
+type (
+	MyTime    time.Time
+	MyTimeStr time.Time
+)
 
 func (t MyTimeStr) String() string {
 	return "<<" + time.Time(t).Format(time.RFC3339Nano) + ">>"


### PR DESCRIPTION
Format the code using gofumpt. Cannot enable it as a linter as it
seems it detects old octal notation as not `gofumpt`-ed.