### PR TITLE
feat(Code): Code can now officially delegate its comparison

### DIFF
--- a/internal/ctxerr/context.go
+++ b/internal/ctxerr/context.go
@@ -7,6 +7,8 @@
 package ctxerr
 
 import (
+	"testing"
+
 	"github.com/maxatome/go-testdeep/internal/anchors"
 	"github.com/maxatome/go-testdeep/internal/hooks"
 	"github.com/maxatome/go-testdeep/internal/location"
@@ -25,10 +27,11 @@ type Context struct {
 	// MaxErrors > 1 stops when MaxErrors'th error encoutered (with a
 	// last "Too many errors" error);
 	// < 0 do not stop until comparison ends.
-	MaxErrors int
-	Errors    *[]*Error
-	Anchors   *anchors.Info
-	Hooks     *hooks.Info
+	MaxErrors  int
+	Errors     *[]*Error
+	Anchors    *anchors.Info
+	Hooks      *hooks.Info
+	OriginalTB testing.TB // only used by Code operator
 	// If true, the contents of the returned *Error will not be
 	// checked. Can be used to avoid filling Error{} with expensive
 	// computations.

--- a/internal/test/types.go
+++ b/internal/test/types.go
@@ -9,6 +9,7 @@ package test
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/maxatome/go-testdeep/internal/trace"
@@ -64,6 +65,27 @@ func (t *TestingT) CatchFatal(fn func()) (fatalStr string) {
 	fn()
 	panicked = false
 	return
+}
+
+// ContainsMessages checks expectedMsgs are all present in Messages, in
+// this order. It stops when a message is not found and returns the
+// remaining messages.
+func (t *TestingT) ContainsMessages(expectedMsgs ...string) []string {
+	curExp := 0
+	for _, msg := range t.Messages {
+		for {
+			if curExp == len(expectedMsgs) {
+				return nil
+			}
+			pos := strings.Index(msg, expectedMsgs[curExp])
+			if pos < 0 {
+				break
+			}
+			msg = msg[pos+len(expectedMsgs[curExp]):]
+			curExp++
+		}
+	}
+	return expectedMsgs[curExp:]
 }
 
 // Helper mocks testing.T Helper method.

--- a/td/cmp_deeply.go
+++ b/td/cmp_deeply.go
@@ -169,6 +169,14 @@ func cmpDeeply(ctx ctxerr.Context, t TestingT, got, expected interface{},
 //   td.Cmp(t, got, "foobar")            // succeeds
 //   td.Cmp(t, got, td.HasPrefix("foo")) // succeeds
 //
+// If "t" is a *T then its Config is inherited, so:
+//
+//   td.Cmp(td.Require(t), got, 42)
+//
+// is the same as:
+//
+//   td.Require(t).Cmp(got, 42)
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -177,7 +185,7 @@ func cmpDeeply(ctx ctxerr.Context, t TestingT, got, expected interface{},
 // reason of a potential failure.
 func Cmp(t TestingT, got, expected interface{}, args ...interface{}) bool {
 	t.Helper()
-	return cmpDeeply(newContext(), t, got, expected, args...)
+	return cmpDeeply(newContext(t), t, got, expected, args...)
 }
 
 // CmpDeeply works the same as Cmp and is still available for
@@ -188,5 +196,5 @@ func Cmp(t TestingT, got, expected interface{}, args ...interface{}) bool {
 //   td.CmpDeeply(t, got, td.HasPrefix("foo")) // succeeds
 func CmpDeeply(t TestingT, got, expected interface{}, args ...interface{}) bool {
 	t.Helper()
-	return cmpDeeply(newContext(), t, got, expected, args...)
+	return cmpDeeply(newContext(t), t, got, expected, args...)
 }

--- a/td/cmp_deeply_test.go
+++ b/td/cmp_deeply_test.go
@@ -194,7 +194,7 @@ func TestStripTrace(t *testing.T) {
 
 func TestFormatError(t *testing.T) {
 	err := &ctxerr.Error{
-		Context: newContext(),
+		Context: newContext(nil),
 		Message: "test error message",
 		Summary: ctxerr.NewSummary("test error summary"),
 	}

--- a/td/cmp_funcs.go
+++ b/td/cmp_funcs.go
@@ -87,6 +87,8 @@ var allOperators = map[string]interface{}{
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -105,6 +107,8 @@ func CmpAll(t TestingT, got interface{}, expectedValues []interface{}, args ...i
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Any for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -125,6 +129,8 @@ func CmpAny(t TestingT, got interface{}, expectedValues []interface{}, args ...i
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -144,6 +150,8 @@ func CmpArray(t TestingT, got, model interface{}, expectedEntries ArrayEntries, 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -162,6 +170,8 @@ func CmpArrayEach(t TestingT, got, expectedValue interface{}, args ...interface{
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Bag for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -186,6 +196,8 @@ func CmpBag(t TestingT, got interface{}, expectedItems []interface{}, args ...in
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -204,6 +216,8 @@ func CmpBetween(t TestingT, got, from, to interface{}, bounds BoundsKind, args .
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Cap for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -224,6 +238,8 @@ func CmpCap(t TestingT, got, expectedCap interface{}, args ...interface{}) bool 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -242,6 +258,8 @@ func CmpCode(t TestingT, got, fn interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Contains for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -262,6 +280,8 @@ func CmpContains(t TestingT, got, expectedValue interface{}, args ...interface{}
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -280,6 +300,8 @@ func CmpContainsKey(t TestingT, got, expectedValue interface{}, args ...interfac
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Empty for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -300,6 +322,8 @@ func CmpEmpty(t TestingT, got interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -318,6 +342,8 @@ func CmpGt(t TestingT, got, minExpectedValue interface{}, args ...interface{}) b
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Gte for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -338,6 +364,8 @@ func CmpGte(t TestingT, got, minExpectedValue interface{}, args ...interface{}) 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -356,6 +384,8 @@ func CmpHasPrefix(t TestingT, got interface{}, expected string, args ...interfac
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#HasSuffix for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -376,6 +406,8 @@ func CmpHasSuffix(t TestingT, got interface{}, expected string, args ...interfac
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -394,6 +426,8 @@ func CmpIsa(t TestingT, got, model interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#JSON for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -414,6 +448,8 @@ func CmpJSON(t TestingT, got, expectedJSON interface{}, params []interface{}, ar
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -432,6 +468,8 @@ func CmpJSONPointer(t TestingT, got interface{}, pointer string, expectedValue i
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Keys for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -452,6 +490,8 @@ func CmpKeys(t TestingT, got, val interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -470,6 +510,8 @@ func CmpLax(t TestingT, got, expectedValue interface{}, args ...interface{}) boo
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Len for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -490,6 +532,8 @@ func CmpLen(t TestingT, got, expectedLen interface{}, args ...interface{}) bool 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -508,6 +552,8 @@ func CmpLt(t TestingT, got, maxExpectedValue interface{}, args ...interface{}) b
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Lte for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -528,6 +574,8 @@ func CmpLte(t TestingT, got, maxExpectedValue interface{}, args ...interface{}) 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -546,6 +594,8 @@ func CmpMap(t TestingT, got, model interface{}, expectedEntries MapEntries, args
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#MapEach for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -570,6 +620,8 @@ func CmpMapEach(t TestingT, got, expectedValue interface{}, args ...interface{})
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -588,6 +640,8 @@ func CmpN(t TestingT, got, num, tolerance interface{}, args ...interface{}) bool
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#NaN for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -608,6 +662,8 @@ func CmpNaN(t TestingT, got interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -626,6 +682,8 @@ func CmpNil(t TestingT, got interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#None for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -646,6 +704,8 @@ func CmpNone(t TestingT, got interface{}, notExpectedValues []interface{}, args 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -664,6 +724,8 @@ func CmpNot(t TestingT, got, notExpected interface{}, args ...interface{}) bool 
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#NotAny for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -684,6 +746,8 @@ func CmpNotAny(t TestingT, got interface{}, notExpectedItems []interface{}, args
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -702,6 +766,8 @@ func CmpNotEmpty(t TestingT, got interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#NotNaN for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -722,6 +788,8 @@ func CmpNotNaN(t TestingT, got interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -740,6 +808,8 @@ func CmpNotNil(t TestingT, got interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#NotZero for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -760,6 +830,8 @@ func CmpNotZero(t TestingT, got interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -778,6 +850,8 @@ func CmpPPtr(t TestingT, got, val interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Ptr for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -802,6 +876,8 @@ func CmpPtr(t TestingT, got, val interface{}, args ...interface{}) bool {
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -820,6 +896,8 @@ func CmpRe(t TestingT, got, reg, capture interface{}, args ...interface{}) bool 
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#ReAll for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -840,6 +918,8 @@ func CmpReAll(t TestingT, got, reg, capture interface{}, args ...interface{}) bo
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -858,6 +938,8 @@ func CmpSet(t TestingT, got interface{}, expectedItems []interface{}, args ...in
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Shallow for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -878,6 +960,8 @@ func CmpShallow(t TestingT, got, expectedPtr interface{}, args ...interface{}) b
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -896,6 +980,8 @@ func CmpSlice(t TestingT, got, model interface{}, expectedEntries ArrayEntries, 
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Smuggle for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -920,6 +1006,8 @@ func CmpSmuggle(t TestingT, got, fn, expectedValue interface{}, args ...interfac
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -938,6 +1026,8 @@ func CmpSStruct(t TestingT, got, model interface{}, expectedFields StructFields,
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#String for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -962,6 +1052,8 @@ func CmpString(t TestingT, got interface{}, expected string, args ...interface{}
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -980,6 +1072,8 @@ func CmpStruct(t TestingT, got, model interface{}, expectedFields StructFields, 
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#SubBagOf for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -1000,6 +1094,8 @@ func CmpSubBagOf(t TestingT, got interface{}, expectedItems []interface{}, args 
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1018,6 +1114,8 @@ func CmpSubJSONOf(t TestingT, got, expectedJSON interface{}, params []interface{
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#SubMapOf for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -1038,6 +1136,8 @@ func CmpSubMapOf(t TestingT, got, model interface{}, expectedEntries MapEntries,
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1056,6 +1156,8 @@ func CmpSubSetOf(t TestingT, got interface{}, expectedItems []interface{}, args 
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#SuperBagOf for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -1076,6 +1178,8 @@ func CmpSuperBagOf(t TestingT, got interface{}, expectedItems []interface{}, arg
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1094,6 +1198,8 @@ func CmpSuperJSONOf(t TestingT, got, expectedJSON interface{}, params []interfac
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#SuperMapOf for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -1114,6 +1220,8 @@ func CmpSuperMapOf(t TestingT, got, model interface{}, expectedEntries MapEntrie
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1132,6 +1240,8 @@ func CmpSuperSetOf(t TestingT, got interface{}, expectedItems []interface{}, arg
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#SuperSliceOf for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -1156,6 +1266,8 @@ func CmpSuperSliceOf(t TestingT, got, model interface{}, expectedEntries ArrayEn
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1175,6 +1287,8 @@ func CmpTruncTime(t TestingT, got, expectedTime interface{}, trunc time.Duration
 //
 // Returns true if the test is OK, false if it fails.
 //
+// If "t" is a *T then its Config is inherited.
+//
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
 // the first item of "args" is a string and contains a '%' rune then
@@ -1193,6 +1307,8 @@ func CmpValues(t TestingT, got, val interface{}, args ...interface{}) bool {
 // See https://pkg.go.dev/github.com/maxatome/go-testdeep/td#Zero for details.
 //
 // Returns true if the test is OK, false if it fails.
+//
+// If "t" is a *T then its Config is inherited.
 //
 // "args..." are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and

--- a/td/cmp_funcs_misc.go
+++ b/td/cmp_funcs_misc.go
@@ -105,7 +105,7 @@ func cmpNoError(ctx ctxerr.Context, t TestingT, got error, args ...interface{}) 
 // reason of a potential failure.
 func CmpError(t TestingT, got error, args ...interface{}) bool {
 	t.Helper()
-	return cmpError(newContext(), t, got, args...)
+	return cmpError(newContext(t), t, got, args...)
 }
 
 // CmpNoError checks that "got" is nil error.
@@ -123,7 +123,7 @@ func CmpError(t TestingT, got error, args ...interface{}) bool {
 // reason of a potential failure.
 func CmpNoError(t TestingT, got error, args ...interface{}) bool {
 	t.Helper()
-	return cmpNoError(newContext(), t, got, args...)
+	return cmpNoError(newContext(t), t, got, args...)
 }
 
 func cmpPanic(ctx ctxerr.Context, t TestingT, fn func(), expected interface{}, args ...interface{}) bool {
@@ -235,7 +235,7 @@ func cmpNotPanic(ctx ctxerr.Context, t TestingT, fn func(), args ...interface{})
 func CmpPanic(t TestingT, fn func(), expectedPanic interface{},
 	args ...interface{}) bool {
 	t.Helper()
-	return cmpPanic(newContext(), t, fn, expectedPanic, args...)
+	return cmpPanic(newContext(t), t, fn, expectedPanic, args...)
 }
 
 // CmpNotPanic calls "fn" and checks no panic() occurred. If a panic()
@@ -257,5 +257,5 @@ func CmpPanic(t TestingT, fn func(), expectedPanic interface{},
 // reason of a potential failure.
 func CmpNotPanic(t TestingT, fn func(), args ...interface{}) bool {
 	t.Helper()
-	return cmpNotPanic(newContext(), t, fn, args...)
+	return cmpNotPanic(newContext(t), t, fn, args...)
 }

--- a/td/config.go
+++ b/td/config.go
@@ -9,6 +9,7 @@ package td
 import (
 	"os"
 	"strconv"
+	"testing"
 
 	"github.com/maxatome/go-testdeep/internal/anchors"
 	"github.com/maxatome/go-testdeep/internal/ctxerr"
@@ -23,7 +24,8 @@ type ContextConfig struct {
 	// RootName is the string used to represent the root of got data. It
 	// defaults to "DATA". For an HTTP response body, it could be "BODY"
 	// for example.
-	RootName string
+	RootName      string
+	forkedFromCtx *ctxerr.Context
 	// MaxErrors is the maximal number of errors to dump in case of Cmp*
 	// failure.
 	//
@@ -86,6 +88,17 @@ func (c ContextConfig) Equal(o ContextConfig) bool {
 		c.IgnoreUnexported == o.IgnoreUnexported
 }
 
+// OriginalPath returns the current path when the ContextConfig has
+// been built. It always returns RootName except if the ContextConfig
+// has been built by Code operator. See Code documentation for an
+// example of use.
+func (c ContextConfig) OriginalPath() string {
+	if c.forkedFromCtx == nil {
+		return c.RootName
+	}
+	return c.forkedFromCtx.Path.String()
+}
+
 const (
 	contextDefaultRootName = "DATA"
 	contextPanicRootName   = "FUNCTION"
@@ -126,13 +139,17 @@ func (c *ContextConfig) sanitize() {
 
 // newContext creates a new ctxerr.Context using DefaultContextConfig
 // configuration.
-func newContext() ctxerr.Context {
-	return newContextWithConfig(DefaultContextConfig)
+func newContext(t TestingT) ctxerr.Context {
+	if tt, ok := t.(*T); ok {
+		return newContextWithConfig(tt, tt.Config)
+	}
+	tb, _ := t.(testing.TB)
+	return newContextWithConfig(tb, DefaultContextConfig)
 }
 
 // newContextWithConfig creates a new ctxerr.Context using a specific
 // configuration.
-func newContextWithConfig(config ContextConfig) (ctx ctxerr.Context) {
+func newContextWithConfig(tb testing.TB, config ContextConfig) (ctx ctxerr.Context) {
 	config.sanitize()
 
 	ctx = ctxerr.Context{
@@ -141,6 +158,7 @@ func newContextWithConfig(config ContextConfig) (ctx ctxerr.Context) {
 		MaxErrors:        config.MaxErrors,
 		Anchors:          config.anchors,
 		Hooks:            config.hooks,
+		OriginalTB:       tb,
 		FailureIsFatal:   config.FailureIsFatal,
 		UseEqual:         config.UseEqual,
 		BeLax:            config.BeLax,

--- a/td/equal.go
+++ b/td/equal.go
@@ -464,7 +464,7 @@ func EqDeeply(got, expected interface{}) bool {
 //     // …
 //   }
 func EqDeeplyError(got, expected interface{}) error {
-	err := deepValueEqualFinal(newContext(),
+	err := deepValueEqualFinal(newContext(nil),
 		reflect.ValueOf(got), reflect.ValueOf(expected))
 	if err == nil {
 		return nil

--- a/td/example_cmp_test.go
+++ b/td/example_cmp_test.go
@@ -438,6 +438,27 @@ func ExampleCmpCode() {
 	// true
 }
 
+func ExampleCmpCode_custom() {
+	t := &testing.T{}
+
+	got := 123
+
+	ok := td.CmpCode(t, got, func(t *td.T, num int) {
+		t.Cmp(num, 123)
+	})
+	fmt.Println("with one *td.T:", ok)
+
+	ok = td.CmpCode(t, got, func(assert, require *td.T, num int) {
+		assert.Cmp(num, 123)
+		require.Cmp(num, 123)
+	})
+	fmt.Println("with assert & require *td.T:", ok)
+
+	// Output:
+	// with one *td.T: true
+	// with assert & require *td.T: true
+}
+
 func ExampleCmpContains_arraySlice() {
 	t := &testing.T{}
 

--- a/td/example_t_test.go
+++ b/td/example_t_test.go
@@ -438,6 +438,27 @@ func ExampleT_Code() {
 	// true
 }
 
+func ExampleT_Code_custom() {
+	t := td.NewT(&testing.T{})
+
+	got := 123
+
+	ok := t.Code(got, func(t *td.T, num int) {
+		t.Cmp(num, 123)
+	})
+	fmt.Println("with one *td.T:", ok)
+
+	ok = t.Code(got, func(assert, require *td.T, num int) {
+		assert.Cmp(num, 123)
+		require.Cmp(num, 123)
+	})
+	fmt.Println("with assert & require *td.T:", ok)
+
+	// Output:
+	// with one *td.T: true
+	// with assert & require *td.T: true
+}
+
 func ExampleT_Contains_arraySlice() {
 	t := td.NewT(&testing.T{})
 

--- a/td/example_test.go
+++ b/td/example_test.go
@@ -594,6 +594,27 @@ func ExampleCode() {
 	// true
 }
 
+func ExampleCode_custom() {
+	t := &testing.T{}
+
+	got := 123
+
+	ok := td.Cmp(t, got, td.Code(func(t *td.T, num int) {
+		t.Cmp(num, 123)
+	}))
+	fmt.Println("with one *td.T:", ok)
+
+	ok = td.Cmp(t, got, td.Code(func(assert, require *td.T, num int) {
+		assert.Cmp(num, 123)
+		require.Cmp(num, 123)
+	}))
+	fmt.Println("with assert & require *td.T:", ok)
+
+	// Output:
+	// with one *td.T: true
+	// with assert & require *td.T: true
+}
+
 func ExampleContains_arraySlice() {
 	t := &testing.T{}
 

--- a/td/t_struct.go
+++ b/td/t_struct.go
@@ -418,8 +418,7 @@ func (t *T) IgnoreUnexported(types ...interface{}) *T {
 func (t *T) Cmp(got, expected interface{}, args ...interface{}) bool {
 	t.Helper()
 	defer t.resetNonPersistentAnchors()
-	return cmpDeeply(newContextWithConfig(t.Config),
-		t.TB, got, expected, args...)
+	return cmpDeeply(newContext(t), t.TB, got, expected, args...)
 }
 
 // CmpDeeply works the same as Cmp and is still available for
@@ -427,8 +426,7 @@ func (t *T) Cmp(got, expected interface{}, args ...interface{}) bool {
 func (t *T) CmpDeeply(got, expected interface{}, args ...interface{}) bool {
 	t.Helper()
 	defer t.resetNonPersistentAnchors()
-	return cmpDeeply(newContextWithConfig(t.Config),
-		t.TB, got, expected, args...)
+	return cmpDeeply(newContext(t), t.TB, got, expected, args...)
 }
 
 // True is shortcut for:
@@ -484,7 +482,7 @@ func (t *T) False(got interface{}, args ...interface{}) bool {
 // reason of a potential failure.
 func (t *T) CmpError(got error, args ...interface{}) bool {
 	t.Helper()
-	return cmpError(newContextWithConfig(t.Config), t.TB, got, args...)
+	return cmpError(newContext(t), t.TB, got, args...)
 }
 
 // CmpNoError checks that "got" is nil error.
@@ -504,7 +502,7 @@ func (t *T) CmpError(got error, args ...interface{}) bool {
 // reason of a potential failure.
 func (t *T) CmpNoError(got error, args ...interface{}) bool {
 	t.Helper()
-	return cmpNoError(newContextWithConfig(t.Config), t.TB, got, args...)
+	return cmpNoError(newContext(t), t.TB, got, args...)
 }
 
 // CmpPanic calls "fn" and checks a panic() occurred with the
@@ -533,7 +531,7 @@ func (t *T) CmpNoError(got error, args ...interface{}) bool {
 func (t *T) CmpPanic(fn func(), expected interface{}, args ...interface{}) bool {
 	t.Helper()
 	defer t.resetNonPersistentAnchors()
-	return cmpPanic(newContextWithConfig(t.Config), t, fn, expected, args...)
+	return cmpPanic(newContext(t), t, fn, expected, args...)
 }
 
 // CmpNotPanic calls "fn" and checks no panic() occurred. If a panic()
@@ -555,7 +553,7 @@ func (t *T) CmpPanic(fn func(), expected interface{}, args ...interface{}) bool 
 // reason of a potential failure.
 func (t *T) CmpNotPanic(fn func(), args ...interface{}) bool {
 	t.Helper()
-	return cmpNotPanic(newContextWithConfig(t.Config), t, fn, args...)
+	return cmpNotPanic(newContext(t), t, fn, args...)
 }
 
 // Parallel marks this test as runnable in parallel with other parallel tests.

--- a/td/types.go
+++ b/td/types.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	tType              = reflect.TypeOf((*T)(nil))
 	testDeeper         = reflect.TypeOf((*TestDeep)(nil)).Elem()
 	smuggledGotType    = reflect.TypeOf(SmuggledGot{})
 	smuggledGotPtrType = reflect.TypeOf((*SmuggledGot)(nil))

--- a/td/utils_test.go
+++ b/td/utils_test.go
@@ -40,7 +40,7 @@ func TestGetTime(t *testing.T) {
 	} {
 		testName := fmt.Sprintf("Test #%d: ", idx)
 
-		tm, err := getTime(newContext(),
+		tm, err := getTime(newContext(nil),
 			reflect.ValueOf(curTest.ParamGot), curTest.ParamMustConvert)
 
 		if !tm.Equal(curTest.ExpectedTime) {
@@ -62,7 +62,7 @@ func TestGetTime(t *testing.T) {
 	}
 
 	// Error cases
-	for idx, ctx := range []ctxerr.Context{newContext(), newBooleanContext()} {
+	for idx, ctx := range []ctxerr.Context{newContext(nil), newBooleanContext()} {
 		testName := fmt.Sprintf("Test #%d: ", idx)
 
 		tm, err := getTime(ctx, reflect.ValueOf(oneTime), false)


### PR DESCRIPTION
Using two new kinds of function:
- `func(t *td.T, arg)`
- `func(assert, require *td.T, arg)`

this way the usage of `*td.T` methods is secure. Note that these
functions do not return anything.

At the same time, using a `*td.T` instance as `Cmp*` first parameter
allows to inherit its configuration.
```
td.Cmp(td.Require(t), got, 42)
```
is the same as:
```
td.Require(t).Cmp(got, 42)
```