### PR TITLE
test: fix test related to go1.19 change

### DIFF
--- a/helpers/tdhttp/internal/response_test.go
+++ b/helpers/tdhttp/internal/response_test.go
@@ -103,6 +103,6 @@ lines
 	tb.ResetMessages()
 	internal.DumpResponse(tb, newResponse("\x7f"))
 	td.Cmp(t, tb.LastMessage(),
-		`Received response:
-"HTTP/1.0 200 OK\r\nA: foo\r\nB: bar\r\n\r\n\u007f"`)
+		td.Re(`Received response:
+"HTTP/1.0 200 OK\\r\\nA: foo\\r\\nB: bar\\r\\n\\r\\n(\\u007f|\\x7f)"`))
 }


### PR DESCRIPTION
7f char is no longer escaped as \u007f in strings but \x7f.