### PR TITLE
feat: add TestDeepInGotOK allowing to test td.TestDeep operators

### DIFF
--- a/internal/ctxerr/context.go
+++ b/internal/ctxerr/context.go
@@ -44,6 +44,8 @@ type Context struct {
 	BeLax bool
 	// See ContextConfig.IgnoreUnexported for details.
 	IgnoreUnexported bool
+	// See ContextConfig.TestDeepInGotOK for details.
+	TestDeepInGotOK bool
 }
 
 // InitErrors initializes [Context] *Errors slice, if MaxErrors < 0 or

--- a/td/config.go
+++ b/td/config.go
@@ -75,6 +75,11 @@ type ContextConfig struct {
 	// See (*T).IgnoreUnexported method to only apply this property to some
 	// specific types.
 	IgnoreUnexported bool
+	// TestDeepInGotOK allows to accept TestDeep operator in got Cmp*
+	// parameter. By default it is forbidden and a panic occurs, because
+	// most of the time it is a mistake to compare (expected, got)
+	// instead of official (got, expected).
+	TestDeepInGotOK bool
 }
 
 // Equal returns true if both c and o are equal. Only public fields
@@ -85,7 +90,8 @@ func (c ContextConfig) Equal(o ContextConfig) bool {
 		c.FailureIsFatal == o.FailureIsFatal &&
 		c.UseEqual == o.UseEqual &&
 		c.BeLax == o.BeLax &&
-		c.IgnoreUnexported == o.IgnoreUnexported
+		c.IgnoreUnexported == o.IgnoreUnexported &&
+		c.TestDeepInGotOK == o.TestDeepInGotOK
 }
 
 // OriginalPath returns the current path when the [ContextConfig] has
@@ -126,6 +132,7 @@ var DefaultContextConfig = ContextConfig{
 	UseEqual:         false,
 	BeLax:            false,
 	IgnoreUnexported: false,
+	TestDeepInGotOK:  false,
 }
 
 func (c *ContextConfig) sanitize() {
@@ -163,6 +170,7 @@ func newContextWithConfig(tb testing.TB, config ContextConfig) (ctx ctxerr.Conte
 		UseEqual:         config.UseEqual,
 		BeLax:            config.BeLax,
 		IgnoreUnexported: config.IgnoreUnexported,
+		TestDeepInGotOK:  config.TestDeepInGotOK,
 	}
 
 	ctx.InitErrors()
@@ -177,5 +185,6 @@ func newBooleanContext() ctxerr.Context {
 		UseEqual:         DefaultContextConfig.UseEqual,
 		BeLax:            DefaultContextConfig.BeLax,
 		IgnoreUnexported: DefaultContextConfig.IgnoreUnexported,
+		TestDeepInGotOK:  DefaultContextConfig.TestDeepInGotOK,
 	}
 }

--- a/td/config_test.go
+++ b/td/config_test.go
@@ -29,11 +29,12 @@ func TestContext(t *testing.T) {
 		}
 	}
 
-	nctx = newContext(Require(t).UseEqual())
+	nctx = newContext(Require(t).UseEqual().TestDeepInGotOK())
 	_, ok := nctx.OriginalTB.(*T)
 	test.IsTrue(t, ok)
 	test.IsTrue(t, nctx.FailureIsFatal)
 	test.IsTrue(t, nctx.UseEqual)
+	test.IsTrue(t, nctx.TestDeepInGotOK)
 	test.EqualStr(t, nctx.Path.String(), "DATA")
 
 	nctx = newBooleanContext()

--- a/td/equal.go
+++ b/td/equal.go
@@ -125,10 +125,12 @@ func resolveAnchor(ctx ctxerr.Context, v reflect.Value) (reflect.Value, bool) {
 }
 
 func deepValueEqual(ctx ctxerr.Context, got, expected reflect.Value) (err *ctxerr.Error) {
-	// got must not implement testDeeper
-	if got.IsValid() && got.Type().Implements(testDeeper) {
-		panic(color.Bad("Found a TestDeep operator in got param, " +
-			"can only use it in expected one!"))
+	if !ctx.TestDeepInGotOK {
+		// got must not implement testDeeper
+		if got.IsValid() && got.Type().Implements(testDeeper) {
+			panic(color.Bad("Found a TestDeep operator in got param, " +
+				"can only use it in expected one!"))
+		}
 	}
 
 	// Try to see if a TestDeep operator is anchored in expected

--- a/td/equal_test.go
+++ b/td/equal_test.go
@@ -678,6 +678,21 @@ func TestEqualPanic(t *testing.T) {
 			td.EqDeeply(td.Ignore(), td.Ignore())
 		},
 		"Found a TestDeep operator in got param, can only use it in expected one!")
+
+	type tdInside struct {
+		Operator td.TestDeep
+	}
+	test.CheckPanic(t,
+		func() {
+			td.EqDeeply(&tdInside{}, &tdInside{})
+		},
+		"Found a TestDeep operator in got param, can only use it in expected one!")
+
+	t.Cleanup(func() { td.DefaultContextConfig.TestDeepInGotOK = false })
+	td.DefaultContextConfig.TestDeepInGotOK = true
+
+	test.IsTrue(t, td.EqDeeply(td.Ignore(), td.Ignore()))
+	test.IsTrue(t, td.EqDeeply(&tdInside{}, &tdInside{}))
 }
 
 type AssignableType1 struct{ x, Ignore int }

--- a/td/t_struct.go
+++ b/td/t_struct.go
@@ -436,6 +436,20 @@ func (t *T) IgnoreUnexported(types ...any) *T {
 	return t
 }
 
+// TestDeepInGotOK tells go-testdeep to not panic when a [TestDeep]
+// operator is found on got side. By default it is forbidden because
+// most of the time it is a mistake to compare (expected, got) instead
+// of official (got, expected).
+//
+// It returns a new instance of [*T] so does not alter the original t.
+//
+// Note that t.TestDeepInGotOK() acts as t.TestDeepInGotOK(true).
+func (t *T) TestDeepInGotOK(enable ...bool) *T {
+	new := *t
+	new.Config.TestDeepInGotOK = len(enable) == 0 || enable[0]
+	return &new
+}
+
 // Cmp is mostly a shortcut for:
 //
 //	Cmp(t.TB, got, expected, args...)

--- a/td/t_struct_test.go
+++ b/td/t_struct_test.go
@@ -546,6 +546,28 @@ func TestIgnoreUnexported(tt *testing.T) {
 		"IgnoreUnexported expects type int be a struct, not a int (@0)")
 }
 
+func TestTestDeepInGotOK(tt *testing.T) {
+	ttt := test.NewTestingTB(tt.Name())
+
+	var t *td.T
+	cmp := func() bool { return t.Cmp(td.Ignore(), td.Ignore()) }
+
+	// Using default config
+	t = td.NewT(ttt)
+	test.CheckPanic(tt, func() { cmp() },
+		"Found a TestDeep operator in got param, can only use it in expected one!")
+
+	t = td.NewT(ttt).TestDeepInGotOK()
+	test.IsTrue(tt, cmp())
+
+	t = t.TestDeepInGotOK(false)
+	test.CheckPanic(tt, func() { cmp() },
+		"Found a TestDeep operator in got param, can only use it in expected one!")
+
+	t = t.TestDeepInGotOK(true)
+	test.IsTrue(tt, cmp())
+}
+
 func TestLogTrace(tt *testing.T) {
 	ttt := test.NewTestingTB(tt.Name())
 


### PR DESCRIPTION
TestDeepInGotOK allows to accept TestDeep operator in got Cmp* parameter. By default it is forbidden and a panic occurs, because most of the time it is a mistake to compare (expected, got) instead of official (got, expected).