### PR TITLE
feat(internal): add (*ctxerr.Error).ErrorWithoutColors method

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -100,6 +100,16 @@ func SaveState(on ...bool) func() {
 	}
 }
 
+// On returns true if coloring feature is enabled.
+func On() bool {
+	switch os.Getenv(EnvColor) {
+	case "on", "":
+		return true
+	default: // "off" or any other value
+		return false
+	}
+}
+
 var colors = map[string]byte{
 	"black":   '0',
 	"red":     '1',
@@ -119,15 +129,12 @@ var colors = map[string]byte{
 // If coloring is disabled, returns "", "", "".
 func FromEnv(env, defaultColor string) (string, string, string) {
 	var color string
-	switch os.Getenv(EnvColor) {
-	case "on", "":
+	if On() {
 		if curColor := os.Getenv(env); curColor != "" {
 			color = curColor
 		} else {
 			color = defaultColor
 		}
-	default: // "off" or any other value
-		color = ""
 	}
 
 	if color == "" {

--- a/internal/ctxerr/error_test.go
+++ b/internal/ctxerr/error_test.go
@@ -20,6 +20,13 @@ import (
 func TestError(t *testing.T) {
 	defer color.SaveState()()
 
+	checkWithoutColors := func(err *ctxerr.Error) {
+		t.Helper()
+		test.EqualStr(t, err.ErrorWithoutColors(), err.Error())
+		defer color.SaveState(true)()
+		test.IsTrue(t, err.ErrorWithoutColors() != err.Error())
+	}
+
 	err := ctxerr.Error{
 		Context: ctxerr.Context{
 			Path: ctxerr.NewPath("DATA").AddArrayIndex(12).AddField("Field"),
@@ -32,6 +39,7 @@ func TestError(t *testing.T) {
 		`DATA[12].Field: error message
 	     got: 1
 	expected: 2`)
+	checkWithoutColors(&err)
 	test.EqualStr(t, err.GotString(), "1")
 	test.EqualStr(t, err.ExpectedString(), "2")
 	test.EqualStr(t, err.SummaryString(), "")
@@ -41,18 +49,21 @@ func TestError(t *testing.T) {
 		`Value of DATA[12].Field differ
 	     got: 1
 	expected: 2`)
+	checkWithoutColors(&err)
 
 	err.Message = "Path at end: %%"
 	test.EqualStr(t, err.Error(),
 		`Path at end: DATA[12].Field
 	     got: 1
 	expected: 2`)
+	checkWithoutColors(&err)
 
 	err.Message = "%% <- the path!"
 	test.EqualStr(t, err.Error(),
 		`DATA[12].Field <- the path!
 	     got: 1
 	expected: 2`)
+	checkWithoutColors(&err)
 
 	err = ctxerr.Error{
 		Context: ctxerr.Context{
@@ -72,6 +83,7 @@ func TestError(t *testing.T) {
 	     got: 1
 	expected: 2
 [under operator Operator at file.go:23]`)
+	checkWithoutColors(&err)
 
 	err = ctxerr.Error{
 		Context: ctxerr.Context{
@@ -105,6 +117,7 @@ Originates from following error:
 		42
 	[under operator SubOperator at file2.go:236]
 [under operator Operator at file.go:23]`)
+	checkWithoutColors(&err)
 	test.EqualStr(t, err.GotString(), "")
 	test.EqualStr(t, err.ExpectedString(), "")
 	test.EqualStr(t, err.SummaryString(), "666")
@@ -156,6 +169,7 @@ Originates from following error:
 DATA[13].Field: error message
 	888
 [under operator Operator at file.go:23]`)
+	checkWithoutColors(&err)
 
 	err = ctxerr.Error{
 		Context: ctxerr.Context{Path: ctxerr.NewPath("DATA").AddArrayIndex(12).AddField("Field")},
@@ -203,6 +217,7 @@ Originates from following error:
 DATA[13].Field: error message
 	888
 [under operator Operator at file.go:24]`)
+	checkWithoutColors(&err)
 
 	//
 	// ErrTooManyErrors

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -71,12 +71,27 @@ func IndentString(str, indent string) string {
 }
 
 // IndentStringIn indents str lines (from 2nd one = 1st line is not
-// indented) by indent and write it to w. Before each end of line,
-// colOff is inserted, and after each indent on new line, colOn is
-// inserted.
-func IndentStringIn(w io.Writer, str, indent, colOn, colOff string) {
-	repl := strings.NewReplacer("\n", colOff+"\n"+indent+colOn)
+// indented) by indent and write it to w.
+func IndentStringIn(w io.Writer, str, indent string) {
+	repl := strings.NewReplacer("\n", "\n"+indent)
 	repl.WriteString(w, str) //nolint: errcheck
+}
+
+// IndentColorizeStringIn indents str lines (from 2nd one = 1st line
+// is not indented) by indent and write it to w. Before each end of
+// line, colOff is inserted, and after each indent on new line, colOn
+// is inserted.
+func IndentColorizeStringIn(w io.Writer, str, indent, colOn, colOff string) {
+	if str != "" {
+		if colOn == "" && colOff == "" {
+			IndentStringIn(w, str, indent)
+			return
+		}
+		repl := strings.NewReplacer("\n", colOff+"\n"+indent+colOn)
+		io.WriteString(w, colOn)  //nolint: errcheck
+		repl.WriteString(w, str)  //nolint: errcheck
+		io.WriteString(w, colOff) //nolint: errcheck
+	}
 }
 
 // SliceToString stringifies items slice into buf then returns buf.

--- a/internal/util/string_test.go
+++ b/internal/util/string_test.go
@@ -76,6 +76,14 @@ func TestIndentString(t *testing.T) {
 		{ParamGot: "pipo\nbingo\nzip", Expected: "pipo\n-bingo\n-zip"},
 	} {
 		test.EqualStr(t, util.IndentString(curTest.ParamGot, "-"), curTest.Expected)
+
+		var buf bytes.Buffer
+		util.IndentStringIn(&buf, curTest.ParamGot, "-")
+		test.EqualStr(t, buf.String(), curTest.Expected)
+
+		buf.Reset()
+		util.IndentColorizeStringIn(&buf, curTest.ParamGot, "-", "", "")
+		test.EqualStr(t, buf.String(), curTest.Expected)
 	}
 
 	for _, curTest := range []struct {
@@ -83,11 +91,11 @@ func TestIndentString(t *testing.T) {
 		Expected string
 	}{
 		{ParamGot: "", Expected: ""},
-		{ParamGot: "pipo", Expected: "pipo"},
-		{ParamGot: "pipo\nbingo\nzip", Expected: "pipo>>\n-<<bingo>>\n-<<zip"},
+		{ParamGot: "pipo", Expected: "<<pipo>>"},
+		{ParamGot: "pipo\nbingo\nzip", Expected: "<<pipo>>\n-<<bingo>>\n-<<zip>>"},
 	} {
 		var buf bytes.Buffer
-		util.IndentStringIn(&buf, curTest.ParamGot, "-", "<<", ">>")
+		util.IndentColorizeStringIn(&buf, curTest.ParamGot, "-", "<<", ">>")
 		test.EqualStr(t, buf.String(), curTest.Expected)
 	}
 }

--- a/td/cmp_deeply.go
+++ b/td/cmp_deeply.go
@@ -130,7 +130,7 @@ func formatError(t TestingT, isFatal bool, err *ctxerr.Error, args ...any) {
 	color.AppendTestNameOff(&buf)
 	buf.WriteString("\n")
 
-	err.Append(&buf, "")
+	err.Append(&buf, "", true)
 
 	// Stask trace
 	if s := stripTrace(trace.Retrieve(0, "testing.tRunner")); s.IsRelevant() {


### PR DESCRIPTION
It is the same as `(*ctxerr.Error).Error`, but the string it returns does not contain any ANSI color escape sequences.