### PR TITLE
feat: add generic functions td.Anchor and td.A, another way to anchor

### DIFF
--- a/td/t_anchor_119.go
+++ b/td/t_anchor_119.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.19
+// +build go1.19
+
+package td
+
+// Anchor is a generic shortcut to [T.Anchor].
+func Anchor[X any](t *T, operator TestDeep) X {
+	var model X
+	return t.Anchor(operator, model).(X)
+}
+
+// A is a generic shortcut to [T.A].
+func A[X any](t *T, operator TestDeep) X {
+	var model X
+	return t.A(operator, model).(X)
+}

--- a/td/t_anchor_119_test.go
+++ b/td/t_anchor_119_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.19
+// +build go1.19
+
+package td_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maxatome/go-testdeep/internal/test"
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestAnchor(tt *testing.T) {
+	ttt := test.NewTestingTB(tt.Name())
+	t := td.NewT(ttt)
+	type MyStruct struct {
+		PNum  *int
+		Num   int64
+		Str   string
+		Slice []int
+		Map   map[string]bool
+		Time  time.Time
+	}
+	n := 42
+	got := MyStruct{
+		PNum: &n,
+		Num:  136,
+		Str:  "Pipo bingo",
+		Time: timeParse(tt, "2019-01-02T11:22:33.123456Z"),
+	}
+
+	td.CmpTrue(tt,
+		t.Cmp(got, MyStruct{
+			PNum: td.Anchor[*int](t, td.Ptr(td.Between(40, 45))),
+			Num:  td.Anchor[int64](t, td.Between(int64(135), int64(137))),
+			Str:  td.Anchor[string](t, td.HasPrefix("Pipo")),
+			Time: td.Anchor[time.Time](t, td.TruncTime(timeParse(tt, "2019-01-02T11:22:00Z"), time.Minute)),
+		}))
+
+	td.CmpTrue(tt,
+		t.Cmp(got, MyStruct{
+			PNum: td.A[*int](t, td.Ptr(td.Between(40, 45))),
+			Num:  td.A[int64](t, td.Between(int64(135), int64(137))),
+			Str:  td.A[string](t, td.HasPrefix("Pipo")),
+			Time: td.A[time.Time](t, td.TruncTime(timeParse(tt, "2019-01-02T11:22:00Z"), time.Minute)),
+		}))
+}

--- a/td/t_anchor_test.go
+++ b/td/t_anchor_test.go
@@ -23,7 +23,7 @@ func timeParse(t *testing.T, s string) time.Time {
 	return dt
 }
 
-func TestAnchor(tt *testing.T) {
+func TestT_Anchor(tt *testing.T) {
 	ttt := test.NewTestingTB(tt.Name())
 	t := td.NewT(ttt)
 	type MyStruct struct {
@@ -140,7 +140,7 @@ func TestAddAnchorableStructType(tt *testing.T) {
 		"usage: AddAnchorableStructType(func (nextAnchor int) STRUCT_TYPE)")
 }
 
-func TestAnchorsPersist(tt *testing.T) {
+func TestT_AnchorsPersist(tt *testing.T) {
 	ttt := test.NewTestingTB(tt.Name())
 
 	t1 := td.NewT(ttt)


### PR DESCRIPTION
```
td.Anchor[string](t, td.HasPrefix("Pipo"))
```
vs
```
t.Anchor(td.HasPrefix("Pipo"), "").(string)
```