### PR TITLE
fix(JSON): errors with wrong origin operator

### DIFF
--- a/td/equal.go
+++ b/td/equal.go
@@ -55,7 +55,9 @@ func nilHandler(ctx ctxerr.Context, got, expected reflect.Value) *ctxerr.Error {
 	if expected.IsValid() { // here: !got.IsValid()
 		if expected.Type().Implements(testDeeper) {
 			curOperator := dark.MustGetInterface(expected).(TestDeep)
-			ctx.CurOperator = curOperator
+			if curOperator.GetLocation().IsInitialized() {
+				ctx.CurOperator = curOperator
+			}
 			if curOperator.HandleInvalid() {
 				return curOperator.Match(ctx, got)
 			}
@@ -201,7 +203,9 @@ func deepValueEqual(ctx ctxerr.Context, got, expected reflect.Value) (err *ctxer
 				}
 			}
 
-			ctx.CurOperator = curOperator
+			if curOperator.GetLocation().IsInitialized() {
+				ctx.CurOperator = curOperator
+			}
 			return curOperator.Match(ctx, got)
 		}
 

--- a/td/td_json.go
+++ b/td/td_json.go
@@ -330,7 +330,7 @@ type tdJSONPlaceholder struct {
 func newJSONNamedPlaceholder(name string, expectedValue any) TestDeep {
 	p := tdJSONPlaceholder{
 		tdJSONSmuggler: tdJSONSmuggler{
-			tdSmugglerBase: newSmugglerBase(expectedValue, 1),
+			tdSmugglerBase: newSmugglerBase(expectedValue, -100), // without location
 		},
 		name: name,
 	}
@@ -344,7 +344,7 @@ func newJSONNamedPlaceholder(name string, expectedValue any) TestDeep {
 func newJSONNumPlaceholder(num uint64, expectedValue any) TestDeep {
 	p := tdJSONPlaceholder{
 		tdJSONSmuggler: tdJSONSmuggler{
-			tdSmugglerBase: newSmugglerBase(expectedValue, 1),
+			tdSmugglerBase: newSmugglerBase(expectedValue, -100), // without location
 		},
 		num: num,
 	}
@@ -397,11 +397,12 @@ type tdJSONEmbedded struct {
 }
 
 func newJSONEmbedded(tdOp TestDeep) TestDeep {
-	return &tdJSONEmbedded{
+	e := tdJSONEmbedded{
 		tdJSONSmuggler: tdJSONSmuggler{
-			tdSmugglerBase: newSmugglerBase(tdOp, 1),
+			tdSmugglerBase: newSmugglerBase(tdOp, -100), // without location
 		},
 	}
+	return &e
 }
 
 func (e *tdJSONEmbedded) MarshalJSON() ([]byte, error) {

--- a/td/td_map.go
+++ b/td/td_map.go
@@ -322,7 +322,7 @@ func (m *tdMap) match(ctx ctxerr.Context, got reflect.Value) (err *ctxerr.Error)
 		}
 
 		err = deepValueEqual(ctx.AddMapKey(entryInfo.key),
-			got.MapIndex(entryInfo.key), entryInfo.expected)
+			gotValue, entryInfo.expected)
 		if err != nil {
 			return err
 		}

--- a/td/types.go
+++ b/td/types.go
@@ -87,6 +87,9 @@ func pkgFunc(full string) (string, string) {
 
 // setLocation sets location using the stack trace going callDepth levels up.
 func (t *base) setLocation(callDepth int) {
+	if callDepth < 0 {
+		return
+	}
 	var ok bool
 	t.location, ok = location.New(callDepth)
 	if !ok {


### PR DESCRIPTION
In error reports, the origin operator was sometimes missing and sometimes wrong when using JSON, SubJSONOf and SuperJSONOf operators, as in:

        [under operator tdJSONUnmarshaler.resolveOp.func1 at lex.go:156]

Now the location of internal operators, as the ones used by JSON operators, cannot appear in error reports anymore and so do not mask the location of user visible operators.