### PR TITLE
feat(tdhttp): add testAPI.Clone feature

### DIFF
--- a/helpers/tdhttp/test_api.go
+++ b/helpers/tdhttp/test_api.go
@@ -113,9 +113,9 @@ func (ta *TestAPI) Clone() *TestAPI {
 		ta.defaultHeader, ta.defaultQParams, ta.defaultCookies)
 }
 
-// With creates a new [*TestAPI] instance copied from t, but resetting
+// With creates a new [*TestAPI] instance copied from ta, but resetting
 // the [testing.TB] instance the tests are based on to tb. The
-// returned instance is independent from t, sharing only the same
+// returned instance is independent from ta, sharing only the same
 // handler. The header values, query params and cookies defined using
 // [TestAPI.DefaultRequestParams] or [TestAPI.AddDefaultRequestParams]
 // are also copied.

--- a/helpers/tdhttp/test_api_test.go
+++ b/helpers/tdhttp/test_api_test.go
@@ -1207,6 +1207,31 @@ func TestWith(t *testing.T) {
 	td.CmpContains(t, nt.LogBuf(), "X-Testdeep-Method: HEAD") // Header dumped
 }
 
+func TestClone(t *testing.T) {
+	mux := server()
+
+	ta := tdhttp.NewTestAPI(t, mux)
+	nta := ta.Clone().DefaultRequestParams(
+		"X-Test", "bingo", "X-Zip", "OK",
+		tdhttp.Q{"a": "pizza", "b": "kiss"},
+		http.Cookie{Name: "cook1", Value: "VAL1"},
+	)
+
+	td.Cmp(t, nta.T(), td.Shallow(ta.T()), "ta and nta share the same testing.TB")
+	td.Cmp(t, nta, td.Struct(nil, td.StructFields{
+		"defaultHeader":  http.Header{"X-Test": {"bingo"}, "X-Zip": {"OK"}},
+		"defaultQParams": url.Values{"a": {"pizza"}, "b": {"kiss"}},
+		"defaultCookies": []*http.Cookie{
+			{Name: "cook1", Value: "VAL1"},
+		},
+	}), "nta modified successfully")
+	td.Cmp(t, ta, td.Struct(nil, td.StructFields{
+		"defaultHeader":  nil,
+		"defaultQParams": nil,
+		"defaultCookies": nil,
+	}), "ta was not modified")
+}
+
 func TestDefaultRequestParams(t *testing.T) {
 	mux := server()
 


### PR DESCRIPTION
A testAPI can now be cloned without using the With statement.