### PR TITLE
feat(tdhttp): request creation methods/functions init Host field

### DIFF
--- a/helpers/tdhttp/request.go
+++ b/helpers/tdhttp/request.go
@@ -35,18 +35,28 @@ func newRequest(method string, target string, body io.Reader, headersQueryParams
 	if err != nil {
 		return nil, errors.New(color.Bad("target is not a valid path: %s", err))
 	}
+	host := u.Host
+	u.Host = ""
+	u.Scheme = ""
 	if len(qp) > 0 {
 		if u.RawQuery != "" {
 			u.RawQuery += "&"
 		}
 		u.RawQuery += qp.Encode()
-		target = u.String()
 	}
+	target = u.String()
 
 	req := httptest.NewRequest(method, target, body)
 
 	for k, v := range header {
 		req.Header[k] = append(req.Header[k], v...)
+	}
+
+	if host == "" {
+		host = req.Header.Get("Host")
+	}
+	if host != "" {
+		req.Host = host
 	}
 
 	for _, c := range cookies {

--- a/helpers/tdhttp/request_test.go
+++ b/helpers/tdhttp/request_test.go
@@ -138,6 +138,22 @@ func TestNewRequest(tt *testing.T) {
 		t.Cmp(req.URL.String(), "/path?already=true&p1=123&p3=true")
 	})
 
+	t.Run("NewRequest host", func(t *td.T) {
+		req := tdhttp.NewRequest("GET", "https://pipo.com:123/path", nil)
+		td.Cmp(t, req.Host, "pipo.com:123")
+		td.Cmp(t, req.URL, td.String("/path"))
+
+		req = tdhttp.NewRequest("GET", "/path", nil, "Host", "pipo.com:456")
+		td.Cmp(t, req.Host, "pipo.com:456")
+		td.Cmp(t, req.URL, td.String("/path"))
+
+		req = tdhttp.NewRequest(
+			"GET", "https://pipo.com:123/path", nil,
+			"Host", "bingo.com:456")
+		td.Cmp(t, req.Host, "pipo.com:123", "URL wins")
+		td.Cmp(t, req.URL, td.String("/path"))
+	})
+
 	t.Run("NewRequest panics", func(t *td.T) {
 		t.CmpPanic(
 			func() { tdhttp.NewRequest("GET", "/path", nil, "H", "V", true) },


### PR DESCRIPTION
Accepted target can contain scheme://host:port prefix. If it is the case host:port is used to set Request.Host. If not and the header Host is present, it is used to set Request.Host.