### PR TITLE
Allow the use of testing/synctest

### DIFF
--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -388,7 +388,7 @@ func (badEqualVariadic) Equal(a ...badEqualVariadic) bool { return false }
 
 type badEqualNumIn struct{}
 
-func (badEqualNumIn) Equal(a badEqualNumIn, b badEqualNumIn) bool { return false }
+func (badEqualNumIn) Equal(a, b badEqualNumIn) bool { return false }
 
 type badEqualNumOut struct{}
 

--- a/internal/test/check.go
+++ b/internal/test/check.go
@@ -7,6 +7,7 @@
 package test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"unicode"
@@ -54,6 +55,18 @@ func EqualStr(t *testing.T, got, expected string, args ...any) bool {
 
 	t.Helper()
 	EqualErrorMessage(t, spewIfNeeded(got), spewIfNeeded(expected), args...)
+	return false
+}
+
+// MatchStr checks that got matches expected regexp.
+func MatchStr(t *testing.T, got, expectedRe string, args ...any) bool {
+	re := regexp.MustCompile(expectedRe)
+	if re.MatchString(got) {
+		return true
+	}
+
+	t.Helper()
+	EqualErrorMessage(t, spewIfNeeded(got), spewIfNeeded(expectedRe), args...)
 	return false
 }
 

--- a/td/cmp_funcs_misc_121_test.go
+++ b/td/cmp_funcs_misc_121_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2018-2025, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.21
+// +build go1.21
+
+// Until go 1.21 in go.mod
+//go:debug panicnil=0
+
+package td_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func ExampleCmpPanic() {
+	t := &testing.T{}
+
+	ok := td.CmpPanic(t,
+		func() { panic("I am panicking!") }, "I am panicking!",
+		"Checks for panic")
+	fmt.Println("checks exact panic() string:", ok)
+
+	// Can use TestDeep operator too
+	ok = td.CmpPanic(t,
+		func() { panic("I am panicking!") }, td.Contains("panicking!"),
+		"Checks for panic")
+	fmt.Println("checks panic() sub-string:", ok)
+
+	// Can detect panic(nil)
+	// Before Go 1.21, programs that called panic(nil) observed recover
+	// returning nil. Starting in Go 1.21, programs that call panic(nil)
+	// observe recover returning a *PanicNilError. Programs can change
+	// back to the old behavior by setting GODEBUG=panicnil=1.
+	// See https://pkg.go.dev/runtime#PanicNilError
+	ok = td.CmpPanic(t, func() { panic(nil) }, &runtime.PanicNilError{},
+		"Checks for panic(nil)")
+	fmt.Println("checks for panic(nil):", ok)
+
+	// As well as structured data panic
+	type PanicStruct struct {
+		Error string
+		Code  int
+	}
+
+	ok = td.CmpPanic(t,
+		func() {
+			panic(PanicStruct{Error: "Memory violation", Code: 11})
+		},
+		PanicStruct{
+			Error: "Memory violation",
+			Code:  11,
+		})
+	fmt.Println("checks exact panic() struct:", ok)
+
+	// or combined with TestDeep operators too
+	ok = td.CmpPanic(t,
+		func() {
+			panic(PanicStruct{Error: "Memory violation", Code: 11})
+		},
+		td.Struct(PanicStruct{}, td.StructFields{
+			"Code": td.Between(10, 20),
+		}))
+	fmt.Println("checks panic() struct against TestDeep operators:", ok)
+
+	// Of course, do not panic = test failure, even for expected nil
+	// panic parameter
+	ok = td.CmpPanic(t, func() {}, nil)
+	fmt.Println("checks a panic occurred:", ok)
+
+	// Output:
+	// checks exact panic() string: true
+	// checks panic() sub-string: true
+	// checks for panic(nil): true
+	// checks exact panic() struct: true
+	// checks panic() struct against TestDeep operators: true
+	// checks a panic occurred: false
+}

--- a/td/cmp_funcs_misc_test.go
+++ b/td/cmp_funcs_misc_test.go
@@ -77,69 +77,6 @@ func ExampleCmpNoError() {
 	// true
 }
 
-func ExampleCmpPanic() {
-	t := &testing.T{}
-
-	ok := td.CmpPanic(t,
-		func() { panic("I am panicking!") }, "I am panicking!",
-		"Checks for panic")
-	fmt.Println("checks exact panic() string:", ok)
-
-	// Can use TestDeep operator too
-	ok = td.CmpPanic(t,
-		func() { panic("I am panicking!") }, td.Contains("panicking!"),
-		"Checks for panic")
-	fmt.Println("checks panic() sub-string:", ok)
-
-	// Can detect panic(nil)
-	// Before Go 1.21, programs that called panic(nil) observed recover
-	// returning nil. Starting in Go 1.21, programs that call panic(nil)
-	// observe recover returning a *PanicNilError. Programs can change
-	// back to the old behavior by setting GODEBUG=panicnil=1.
-	// See https://pkg.go.dev/runtime#PanicNilError
-	ok = td.CmpPanic(t, func() { panic(nil) }, nil, "Checks for panic(nil)")
-	fmt.Println("checks for panic(nil):", ok)
-
-	// As well as structured data panic
-	type PanicStruct struct {
-		Error string
-		Code  int
-	}
-
-	ok = td.CmpPanic(t,
-		func() {
-			panic(PanicStruct{Error: "Memory violation", Code: 11})
-		},
-		PanicStruct{
-			Error: "Memory violation",
-			Code:  11,
-		})
-	fmt.Println("checks exact panic() struct:", ok)
-
-	// or combined with TestDeep operators too
-	ok = td.CmpPanic(t,
-		func() {
-			panic(PanicStruct{Error: "Memory violation", Code: 11})
-		},
-		td.Struct(PanicStruct{}, td.StructFields{
-			"Code": td.Between(10, 20),
-		}))
-	fmt.Println("checks panic() struct against TestDeep operators:", ok)
-
-	// Of course, do not panic = test failure, even for expected nil
-	// panic parameter
-	ok = td.CmpPanic(t, func() {}, nil)
-	fmt.Println("checks a panic occurred:", ok)
-
-	// Output:
-	// checks exact panic() string: true
-	// checks panic() sub-string: true
-	// checks for panic(nil): true
-	// checks exact panic() struct: true
-	// checks panic() struct against TestDeep operators: true
-	// checks a panic occurred: false
-}
-
 func ExampleCmpNotPanic() {
 	t := &testing.T{}
 

--- a/td/t_struct.go
+++ b/td/t_struct.go
@@ -624,7 +624,8 @@ func (t *T) CmpNoError(got error, args ...any) bool {
 //	  Contains("panicking!"),
 //	  "The function should panic with a string containing `panicking!`")
 //
-//	t.CmpPanic(t, func() { panic(nil) }, nil, "Checks for panic(nil)")
+//	expected := &runtime.PanicNilError{} // should be nil if GODEBUG=panicnil=1
+//	t.CmpPanic(t, func() { panic(nil) }, expected, "Checks for panic(nil)")
 //
 // args... are optional and allow to name the test. This name is
 // used in case of failure to qualify the test. If len(args) > 1 and
@@ -832,7 +833,7 @@ func (t *T) RunAssertRequire(name string, f func(assert, require *T)) bool {
 		reflect.ValueOf(name),
 		reflect.MakeFunc(vfuncs.fnt,
 			func(args []reflect.Value) (results []reflect.Value) {
-				f(AssertRequire(NewT(args[0].Interface().(testing.TB), conf)))
+				f(AssertRequire(args[0].Interface().(testing.TB), conf))
 				return nil
 			}),
 	})

--- a/td/t_struct_examples_121_test.go
+++ b/td/t_struct_examples_121_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2018-2025, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.21
+// +build go1.21
+
+package td_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func ExampleT_CmpPanic() {
+	t := td.NewT(&testing.T{})
+
+	ok := t.CmpPanic(func() { panic("I am panicking!") }, "I am panicking!",
+		"Checks for panic")
+	fmt.Println("checks exact panic() string:", ok)
+
+	// Can use TestDeep operator too
+	ok = t.CmpPanic(
+		func() { panic("I am panicking!") },
+		td.Contains("panicking!"),
+		"Checks for panic")
+	fmt.Println("checks panic() sub-string:", ok)
+
+	// Can detect panic(nil)
+	// Before Go 1.21, programs that called panic(nil) observed recover
+	// returning nil. Starting in Go 1.21, programs that call panic(nil)
+	// observe recover returning a *PanicNilError. Programs can change
+	// back to the old behavior by setting GODEBUG=panicnil=1.
+	// See https://pkg.go.dev/runtime#PanicNilError
+	ok = t.CmpPanic(func() { panic(nil) }, &runtime.PanicNilError{},
+		"Checks for panic(nil)")
+	fmt.Println("checks for panic(nil):", ok)
+
+	// As well as structured data panic
+	type PanicStruct struct {
+		Error string
+		Code  int
+	}
+
+	ok = t.CmpPanic(
+		func() {
+			panic(PanicStruct{Error: "Memory violation", Code: 11})
+		},
+		PanicStruct{
+			Error: "Memory violation",
+			Code:  11,
+		})
+	fmt.Println("checks exact panic() struct:", ok)
+
+	// or combined with TestDeep operators too
+	ok = t.CmpPanic(
+		func() {
+			panic(PanicStruct{Error: "Memory violation", Code: 11})
+		},
+		td.Struct(PanicStruct{}, td.StructFields{
+			"Code": td.Between(10, 20),
+		}))
+	fmt.Println("checks panic() struct against TestDeep operators:", ok)
+
+	// Of course, do not panic = test failure, even for expected nil
+	// panic parameter
+	ok = t.CmpPanic(func() {}, nil)
+	fmt.Println("checks a panic occurred:", ok)
+
+	// Output:
+	// checks exact panic() string: true
+	// checks panic() sub-string: true
+	// checks for panic(nil): true
+	// checks exact panic() struct: true
+	// checks panic() struct against TestDeep operators: true
+	// checks a panic occurred: false
+}

--- a/td/t_struct_examples_test.go
+++ b/td/t_struct_examples_test.go
@@ -77,64 +77,6 @@ func ExampleT_CmpNoError() {
 	// true
 }
 
-func ExampleT_CmpPanic() {
-	t := td.NewT(&testing.T{})
-
-	ok := t.CmpPanic(func() { panic("I am panicking!") }, "I am panicking!",
-		"Checks for panic")
-	fmt.Println("checks exact panic() string:", ok)
-
-	// Can use TestDeep operator too
-	ok = t.CmpPanic(
-		func() { panic("I am panicking!") },
-		td.Contains("panicking!"),
-		"Checks for panic")
-	fmt.Println("checks panic() sub-string:", ok)
-
-	// Can detect panic(nil)
-	ok = t.CmpPanic(func() { panic(nil) }, nil, "Checks for panic(nil)")
-	fmt.Println("checks for panic(nil):", ok)
-
-	// As well as structured data panic
-	type PanicStruct struct {
-		Error string
-		Code  int
-	}
-
-	ok = t.CmpPanic(
-		func() {
-			panic(PanicStruct{Error: "Memory violation", Code: 11})
-		},
-		PanicStruct{
-			Error: "Memory violation",
-			Code:  11,
-		})
-	fmt.Println("checks exact panic() struct:", ok)
-
-	// or combined with TestDeep operators too
-	ok = t.CmpPanic(
-		func() {
-			panic(PanicStruct{Error: "Memory violation", Code: 11})
-		},
-		td.Struct(PanicStruct{}, td.StructFields{
-			"Code": td.Between(10, 20),
-		}))
-	fmt.Println("checks panic() struct against TestDeep operators:", ok)
-
-	// Of course, do not panic = test failure, even for expected nil
-	// panic parameter
-	ok = t.CmpPanic(func() {}, nil)
-	fmt.Println("checks a panic occurred:", ok)
-
-	// Output:
-	// checks exact panic() string: true
-	// checks panic() sub-string: true
-	// checks for panic(nil): true
-	// checks exact panic() struct: true
-	// checks panic() struct against TestDeep operators: true
-	// checks a panic occurred: false
-}
-
 func ExampleT_CmpNotPanic() {
 	t := td.NewT(&testing.T{})
 

--- a/td/t_synctest.go
+++ b/td/t_synctest.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.25
+// +build go1.25
+
+package td
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+// SyncTest is a wrapper around [synctest.Test].
+//
+// The t param of f inherits the configuration of the self-reference.
+//
+// t.TB (set by [NewT], [Assert], [Require], …) must be a [*testing.T]
+// instance.
+func (t *T) SyncTest(f func(t *T)) {
+	tt, ok := t.TB.(*testing.T)
+	if !ok {
+		t.Helper()
+		t.Fatalf("SyncTest only works if underlying T.TB field is a *testing.T, so not a %T", t.TB)
+	}
+	conf := t.Config
+	synctest.Test(tt, func(t *testing.T) {
+		f(NewT(t, conf))
+	})
+}
+
+// SyncTestAssertRequire is a wrapper around [synctest.Test].
+//
+// The assert and require params of f inherit the configuration
+// of the self-reference, except that a failure is never fatal using
+// assert and always fatal using require.
+//
+// t.TB (set by [NewT], [Assert], [Require], …) must be a [*testing.T]
+// instance.
+func (t *T) SyncTestAssertRequire(f func(assert, require *T)) {
+	tt, ok := t.TB.(*testing.T)
+	if !ok {
+		t.Helper()
+		t.Fatalf("SyncTestAssertRequire only works if underlying T.TB field is a *testing.T, so not a %T", t.TB)
+	}
+	conf := t.Config
+	synctest.Test(tt, func(t *testing.T) {
+		f(AssertRequire(t, conf))
+	})
+}

--- a/td/t_synctest_test.go
+++ b/td/t_synctest_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2025, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.25
+// +build go1.25
+
+// Until go 1.23 in go.mod
+//go:debug asynctimerchan=0
+
+package td_test
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/maxatome/go-testdeep/helpers/tdutil"
+	"github.com/maxatome/go-testdeep/internal/test"
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestSyncTest(t *testing.T) {
+	t.Run("testing.T required", func(t *testing.T) {
+		tt := tdutil.NewT(t.Name())
+
+		run := false
+		panicked := tt.CatchFailNow(func() {
+			assert := td.Assert(tt)
+			assert.SyncTest(func(assert *td.T) {
+				run = true
+			})
+		})
+		test.IsFalse(t, run)
+		test.IsTrue(t, panicked)
+		test.MatchStr(t, tt.LogBuf(),
+			`^\s+t_synctest_test\.go:\d+: SyncTest only works if underlying T\.TB field is a \*testing\.T, so not a \*tdutil\.T\n\z`)
+	})
+
+	t.Run("OK1", func(t *testing.T) {
+		run, belax, req := false, false, true
+		assert := td.Assert(t).BeLax()
+		assert.SyncTest(func(assert *td.T) {
+			go func() {
+				run = true
+				belax = assert.Config.BeLax
+				req = assert.Config.FailureIsFatal
+			}()
+			synctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsTrue(t, belax)
+		test.IsFalse(t, req)
+	})
+
+	t.Run("OK2", func(t *testing.T) {
+		run, belax, req := false, true, false
+		require := td.Require(t)
+		require.SyncTest(func(require *td.T) {
+			go func() {
+				run = true
+				belax = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			synctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsFalse(t, belax)
+		test.IsTrue(t, req)
+	})
+}
+
+func TestSyncTestAssertRequire(t *testing.T) {
+	t.Run("testing.T required", func(t *testing.T) {
+		tt := tdutil.NewT(t.Name())
+
+		run := false
+		panicked := tt.CatchFailNow(func() {
+			assert := td.Assert(tt)
+			assert.SyncTestAssertRequire(func(assert, require *td.T) {
+				run = true
+			})
+		})
+		test.IsFalse(t, run)
+		test.IsTrue(t, panicked)
+		test.MatchStr(t, tt.LogBuf(),
+			`^\s+t_synctest_test\.go:\d+: SyncTestAssertRequire only works if underlying T\.TB field is a \*testing\.T, so not a \*tdutil\.T\n\z`)
+	})
+
+	t.Run("OK1", func(t *testing.T) {
+		var run, belaxA, belaxR, ass, req bool
+		assert := td.Assert(t).BeLax()
+		assert.SyncTestAssertRequire(func(assert, require *td.T) {
+			go func() {
+				run = true
+				belaxA = assert.Config.BeLax
+				ass = !assert.Config.FailureIsFatal
+				belaxR = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			synctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsTrue(t, belaxA)
+		test.IsTrue(t, ass)
+		test.IsTrue(t, belaxR)
+		test.IsTrue(t, req)
+	})
+
+	t.Run("OK2", func(t *testing.T) {
+		run, belaxA, belaxR, ass, req := false, true, true, false, false
+		assert := td.Assert(t)
+		assert.SyncTestAssertRequire(func(assert, require *td.T) {
+			go func() {
+				run = true
+				belaxA = assert.Config.BeLax
+				ass = !assert.Config.FailureIsFatal
+				belaxR = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			synctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsFalse(t, belaxA)
+		test.IsTrue(t, ass)
+		test.IsFalse(t, belaxR)
+		test.IsTrue(t, req)
+	})
+}


### PR DESCRIPTION
- add `T.SyncTest` & `T.SyncTestAssertRequire` using [`testing/synctest`](https://pkg.go.dev/testing/synctest)
- BTW enable panicnil=0 as it is since go1.21.

Should the methods be renamed `T.Synctest` & `T.SynctestAssertRequire` instead? @deathiop