### PR TITLE
feat(Flatten): allow func(T, X...) V|(V, bool) function signatures

### DIFF
--- a/td/example_cmp_test.go
+++ b/td/example_cmp_test.go
@@ -2442,6 +2442,48 @@ func ExampleCmpRe_capture() {
 	// false
 }
 
+func ExampleCmpRe_multilines() {
+	t := &testing.T{}
+
+	got := `multi
+lines
+probably
+more
+than 4
+`
+	expectedRe := `^multi
+lines?
+(probably|possibly)
+more
+than \d+
+\z`
+
+	ok := td.CmpRe(t, got, expectedRe, nil)
+	fmt.Println("Raw multi-lines string matches:", ok)
+
+	// But for strings with many, many, many lines, when the regexp
+	// doesn't match, it is sometimes difficult to see where the regexp
+	// failed in the string. Here td.List & td.Flatten can help to apply
+	// regexp line per line (note expectedRe is not anchored anymore):
+	expectedRe = `multi
+lines?
+(probably|possibly)
+more
+than \d+
+`
+	ok = td.Cmp(t,
+		strings.Split(got, "\n"),
+		td.List(td.Flatten(strings.Split(expectedRe, "\n"),
+			func(line string) any {
+				return td.Re(`^` + line + `\z`)
+			})))
+	fmt.Println("All string lines match:", ok)
+
+	// Output:
+	// Raw multi-lines string matches: true
+	// All string lines match: true
+}
+
 func ExampleCmpRe_compiled() {
 	t := &testing.T{}
 

--- a/td/example_t_test.go
+++ b/td/example_t_test.go
@@ -2442,6 +2442,48 @@ func ExampleT_Re_capture() {
 	// false
 }
 
+func ExampleT_Re_multilines() {
+	t := td.NewT(&testing.T{})
+
+	got := `multi
+lines
+probably
+more
+than 4
+`
+	expectedRe := `^multi
+lines?
+(probably|possibly)
+more
+than \d+
+\z`
+
+	ok := t.Re(got, expectedRe, nil)
+	fmt.Println("Raw multi-lines string matches:", ok)
+
+	// But for strings with many, many, many lines, when the regexp
+	// doesn't match, it is sometimes difficult to see where the regexp
+	// failed in the string. Here td.List & td.Flatten can help to apply
+	// regexp line per line (note expectedRe is not anchored anymore):
+	expectedRe = `multi
+lines?
+(probably|possibly)
+more
+than \d+
+`
+	ok = t.Cmp(
+		strings.Split(got, "\n"),
+		td.List(td.Flatten(strings.Split(expectedRe, "\n"),
+			func(line string) any {
+				return td.Re(`^` + line + `\z`)
+			})))
+	fmt.Println("All string lines match:", ok)
+
+	// Output:
+	// Raw multi-lines string matches: true
+	// All string lines match: true
+}
+
 func ExampleT_Re_compiled() {
 	t := td.NewT(&testing.T{})
 

--- a/td/example_test.go
+++ b/td/example_test.go
@@ -2709,6 +2709,48 @@ func ExampleRe_capture() {
 	// false
 }
 
+func ExampleRe_multilines() {
+	t := &testing.T{}
+
+	got := `multi
+lines
+probably
+more
+than 4
+`
+	expectedRe := `^multi
+lines?
+(probably|possibly)
+more
+than \d+
+\z`
+
+	ok := td.Cmp(t, got, td.Re(expectedRe))
+	fmt.Println("Raw multi-lines string matches:", ok)
+
+	// But for strings with many, many, many lines, when the regexp
+	// doesn't match, it is sometimes difficult to see where the regexp
+	// failed in the string. Here td.List & td.Flatten can help to apply
+	// regexp line per line (note expectedRe is not anchored anymore):
+	expectedRe = `multi
+lines?
+(probably|possibly)
+more
+than \d+
+`
+	ok = td.Cmp(t,
+		strings.Split(got, "\n"),
+		td.List(td.Flatten(strings.Split(expectedRe, "\n"),
+			func(line string) any {
+				return td.Re(`^` + line + `\z`)
+			})))
+	fmt.Println("All string lines match:", ok)
+
+	// Output:
+	// Raw multi-lines string matches: true
+	// All string lines match: true
+}
+
 func ExampleReAll_capture() {
 	t := &testing.T{}
 

--- a/td/flatten_test.go
+++ b/td/flatten_test.go
@@ -129,6 +129,14 @@ func TestFlatten(t *testing.T) {
 					int8(15), int8(18), int8(21), int8(24), int8(27),
 				},
 			},
+			{
+				name: "any+variadic",
+				fn: func(a any, opts ...bool) int {
+					x, _ := a.(int)
+					return x
+				},
+				expected: []any{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/td/td_re.go
+++ b/td/td_re.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Maxime Soulé
+// Copyright (c) 2018-2025, Maxime Soulé
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -92,6 +92,20 @@ func newRe(regIf any, capture ...any) *tdRe {
 //	  td.Re(`^(\w+) (\w+)`, []string{"John", "Doe"})) // succeeds
 //	td.Cmp(t, "John Doe",
 //	  td.Re(`^(\w+) (\w+)`, td.Bag("Doe", "John"))) // succeeds
+//
+// When matching many, many lines with a single regexp, it is
+// sometimes difficult to see where the regexp failed in the input
+// string. To avoid that, the regexp can be split by lines and so the
+// failure is easier to locate, thanks to [List] operator and [Flatten]:
+//
+//	td.Cmp(t,
+//	  strings.Split(got, "\n"),
+//	  td.List(td.Flatten(strings.Split(expectedRe, "\n"),
+//	    func(line string) any {
+//	      return `^` + td.Re(line) + `\z`
+//	    })))
+//
+// See also the multilines example.
 //
 // See also [ReAll].
 func Re(reg any, capture ...any) TestDeep {


### PR DESCRIPTION
Allowing to use td.Re as function for example:

    ok = td.Cmp(t,
      strings.Split(got, "\n"),
      td.List(td.Flatten(strings.Split(expectedRe, "\n"), td.Re)))