### PR TITLE
Make go1.27 happy

### DIFF
--- a/helpers/tdsynctest/test.go
+++ b/helpers/tdsynctest/test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Maxime Soulé
+// Copyright (c) 2025-2026, Maxime Soulé
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -12,6 +12,7 @@ package tdsynctest
 import (
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/maxatome/go-testdeep/td"
 )
@@ -22,6 +23,8 @@ import (
 //
 // t.TB (set by [td.NewT], [td.Assert], [td.Require], …) must be a
 // [*testing.T] instance.
+//
+// See also [TestAssertRequire].
 func Test(t *td.T, f func(t *td.T)) {
 	tt, ok := t.TB.(*testing.T)
 	if !ok {
@@ -42,6 +45,8 @@ func Test(t *td.T, f func(t *td.T)) {
 //
 // t.TB (set by [td.NewT], [td.Assert], [td.Require], …) must be a
 // [*testing.T] instance.
+//
+// See also [Test].
 func TestAssertRequire(t *td.T, f func(assert, require *td.T)) {
 	tt, ok := t.TB.(*testing.T)
 	if !ok {
@@ -54,8 +59,61 @@ func TestAssertRequire(t *td.T, f func(assert, require *td.T)) {
 	})
 }
 
+// Subtest runs f in a bubble as a subtest of t called name.
+//
+// The t param of f inherits the configuration of t.
+//
+// t.TB (set by [td.NewT], [td.Assert], [td.Require], …) must be a
+// [*testing.T] instance.
+//
+// See also [SubtestAssertRequire].
+func Subtest(t *td.T, name string, f func(t *td.T)) {
+	t.Helper()
+	tt, ok := t.TB.(*testing.T)
+	if !ok {
+		t.Fatalf("tdsynctest.Subtest only works if underlying T.TB field is a *testing.T, so not a %T", t.TB)
+	}
+	conf := t.Config
+	tt.Run(name, func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			f(td.NewT(t, conf))
+		})
+	})
+}
+
+// SubtestAssertRequire runs f in a bubble as a subtest of t called name.
+//
+// The assert and require params of f inherit the configuration of t,
+// except that a failure is never fatal using assert and always fatal
+// using require.
+//
+// t.TB (set by [td.NewT], [td.Assert], [td.Require], …) must be a
+// [*testing.T] instance.
+//
+// See also [Subtest].
+func SubtestAssertRequire(t *td.T, name string, f func(assert, require *td.T)) {
+	t.Helper()
+	tt, ok := t.TB.(*testing.T)
+	if !ok {
+		t.Fatalf("tdsynctest.SubtestAssertRequire only works if underlying T.TB field is a *testing.T, so not a %T", t.TB)
+	}
+	conf := t.Config
+	tt.Run(name, func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			f(td.AssertRequire(t, conf))
+		})
+	})
+}
+
 // Wait simply calls [synctest.Wait]. It only exists to avoid to
 // import [testing/synctest].
 func Wait() {
 	synctest.Wait()
+}
+
+// Sleep does the same as go1.27 [synctest.Sleep]. It only exists to avoid to
+// import [testing/synctest] and/or when go version is lesser than 1.27.
+func Sleep(d time.Duration) {
+	time.Sleep(d)
+	Wait()
 }

--- a/helpers/tdsynctest/test_test.go
+++ b/helpers/tdsynctest/test_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, Maxime Soulé
+// Copyright (c) 2025-2026, Maxime Soulé
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -14,6 +14,7 @@ package tdsynctest_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/maxatome/go-testdeep/helpers/tdsynctest"
 	"github.com/maxatome/go-testdeep/helpers/tdutil"
@@ -63,7 +64,7 @@ func TestTest(t *testing.T) {
 				belax = require.Config.BeLax
 				req = require.Config.FailureIsFatal
 			}()
-			tdsynctest.Wait()
+			tdsynctest.Sleep(time.Nanosecond)
 		})
 		test.IsTrue(t, run)
 		test.IsFalse(t, belax)
@@ -119,7 +120,115 @@ func TestTestAssertRequire(t *testing.T) {
 				belaxR = require.Config.BeLax
 				req = require.Config.FailureIsFatal
 			}()
+			tdsynctest.Sleep(time.Nanosecond)
+		})
+		test.IsTrue(t, run)
+		test.IsFalse(t, belaxA)
+		test.IsTrue(t, ass)
+		test.IsFalse(t, belaxR)
+		test.IsTrue(t, req)
+	})
+}
+
+func TestSubtest(t *testing.T) {
+	t.Run("testing.T required", func(t *testing.T) {
+		tt := tdutil.NewT(t.Name())
+
+		run := false
+		failed := tt.CatchFailNow(func() {
+			assert := td.Assert(tt)
+			tdsynctest.Subtest(assert, "name", func(t *td.T) {
+				run = true
+			})
+		})
+		test.IsFalse(t, run)
+		test.IsTrue(t, failed)
+		test.MatchStr(t, tt.LogBuf(),
+			`^\s+test_test\.go:\d+: tdsynctest\.Subtest only works if underlying T\.TB field is a \*testing\.T, so not a \*tdutil\.T\n\z`)
+	})
+
+	t.Run("OK1", func(t *testing.T) {
+		run, belax, req := false, false, true
+		assert := td.Assert(t).BeLax()
+		tdsynctest.Subtest(assert, "name", func(assert *td.T) {
+			go func() {
+				run = true
+				belax = assert.Config.BeLax
+				req = assert.Config.FailureIsFatal
+			}()
 			tdsynctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsTrue(t, belax)
+		test.IsFalse(t, req)
+	})
+
+	t.Run("OK2", func(t *testing.T) {
+		run, belax, req := false, true, false
+		require := td.Require(t)
+		tdsynctest.Subtest(require, "name", func(require *td.T) {
+			go func() {
+				run = true
+				belax = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			tdsynctest.Sleep(time.Nanosecond)
+		})
+		test.IsTrue(t, run)
+		test.IsFalse(t, belax)
+		test.IsTrue(t, req)
+	})
+}
+
+func TestSubtestAssertRequire(t *testing.T) {
+	t.Run("testing.T required", func(t *testing.T) {
+		tt := tdutil.NewT(t.Name())
+
+		run := false
+		failed := tt.CatchFailNow(func() {
+			assert := td.Assert(tt)
+			tdsynctest.SubtestAssertRequire(assert, "name", func(assert, require *td.T) {
+				run = true
+			})
+		})
+		test.IsFalse(t, run)
+		test.IsTrue(t, failed)
+		test.MatchStr(t, tt.LogBuf(),
+			`^\s+test_test\.go:\d+: tdsynctest\.SubtestAssertRequire only works if underlying T\.TB field is a \*testing\.T, so not a \*tdutil\.T\n\z`)
+	})
+
+	t.Run("OK1", func(t *testing.T) {
+		var run, belaxA, belaxR, ass, req bool
+		assert := td.Assert(t).BeLax()
+		tdsynctest.SubtestAssertRequire(assert, "name", func(assert, require *td.T) {
+			go func() {
+				run = true
+				belaxA = assert.Config.BeLax
+				ass = !assert.Config.FailureIsFatal
+				belaxR = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			tdsynctest.Wait()
+		})
+		test.IsTrue(t, run)
+		test.IsTrue(t, belaxA)
+		test.IsTrue(t, ass)
+		test.IsTrue(t, belaxR)
+		test.IsTrue(t, req)
+	})
+
+	t.Run("OK2", func(t *testing.T) {
+		run, belaxA, belaxR, ass, req := false, true, true, false, false
+		assert := td.Assert(t)
+		tdsynctest.SubtestAssertRequire(assert, "name", func(assert, require *td.T) {
+			go func() {
+				run = true
+				belaxA = assert.Config.BeLax
+				ass = !assert.Config.FailureIsFatal
+				belaxR = require.Config.BeLax
+				req = require.Config.FailureIsFatal
+			}()
+			tdsynctest.Sleep(time.Nanosecond)
 		})
 		test.IsTrue(t, run)
 		test.IsFalse(t, belaxA)

--- a/td/td_smuggle.go
+++ b/td/td_smuggle.go
@@ -703,8 +703,9 @@ func buildCaster(outType reflect.Type, useString bool) reflect.Value {
 //	// or equally
 //	td.Cmp(t, `{"foo":1}`, td.Smuggle(json.RawMessage(nil), td.JSON(`{"foo":1}`)))
 //
-// converts on the fly a string to a [json.RawMessage] so [JSON] operator
-// can parse it as JSON. This is mostly a shortcut for:
+// converts on the fly a string to a [json.RawMessage] (alias to
+// [jsontext.Value] starting go1.27) so [JSON] operator can parse it
+// as JSON. This is mostly a shortcut for:
 //
 //	td.Cmp(t, `{"foo":1}`, td.Smuggle(
 //	  func(r json.RawMessage) json.RawMessage { return r },
@@ -739,6 +740,7 @@ func buildCaster(outType reflect.Type, useString bool) reflect.Value {
 // See also [Code], [JSONPointer] and [Flatten].
 //
 // [json.RawMessage]: https://pkg.go.dev/encoding/json#RawMessage
+// [jsontext.Value]: https://pkg.go.dev/encoding/json/jsontext#Value
 func Smuggle(fn, expectedValue any) TestDeep {
 	s := tdSmuggle{
 		tdSmugglerBase: newSmugglerBase(expectedValue),

--- a/td/td_smuggle_test.go
+++ b/td/td_smuggle_test.go
@@ -213,13 +213,17 @@ func TestSmuggle(t *testing.T) {
 	checkOK(t, newReArmReader([]byte(`{"foo":1}`)), // io.Reader first
 		td.Smuggle(json.RawMessage{}, td.JSON(`{"foo":1}`)))
 
+	// Use %T as starting go1.27, json.RawMessage is now an alias to
+	// jsontext.Value
+	jsonRawMessageType := fmt.Sprintf("%T", json.RawMessage{})
+
 	checkError(t, nil,
 		td.Smuggle(json.RawMessage{}, td.JSON(`{}`)),
 		expectedError{
 			Message:  mustBe("incompatible parameter type"),
 			Path:     mustBe("DATA"),
 			Got:      mustBe("nil"),
-			Expected: mustBe("json.RawMessage or convertible or io.Reader"),
+			Expected: mustBe(jsonRawMessageType + " or convertible or io.Reader"),
 		})
 
 	checkError(t, MyStruct{},
@@ -228,7 +232,7 @@ func TestSmuggle(t *testing.T) {
 			Message:  mustBe("incompatible parameter type"),
 			Path:     mustBe("DATA"),
 			Got:      mustBe("td_test.MyStruct"),
-			Expected: mustBe("json.RawMessage or convertible or io.Reader"),
+			Expected: mustBe(jsonRawMessageType + " or convertible or io.Reader"),
 		})
 
 	checkError(t, errReader{}, // erroneous io.Reader

--- a/td/types_127_test.go
+++ b/td/types_127_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, Maxime Soulé
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build go1.27
+// +build go1.27
+
+package td_test
+
+import "fmt"
+
+func init() {
+	// Starting go1.27, the first file of the stack trace is not
+	// types_test.go but module_path/td/types_test.go. So as a "/" is
+	// detected in file name, go-testdeep automatically add "This is how
+	// we got here" paragraph.
+	thisIsHowWeGotHere = func(line int) string {
+		return fmt.Sprintf(`        This is how we got here:
+        	TestSetlocation() td/types_test.go:%d
+`, line)
+	}
+}

--- a/td/types_test.go
+++ b/td/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Maxime Soulé
+// Copyright (c) 2019-2026, Maxime Soulé
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -16,6 +16,12 @@ import (
 	"github.com/maxatome/go-testdeep/td"
 )
 
+// Starting go1.27, the first file of the stack trace is not
+// types_test.go but module_path/td/types_test.go. So as a "/" is
+// detected in file name, go-testdeep automatically add "This is how
+// we got here" paragraph.
+var thisIsHowWeGotHere = func(line int) string { return "" }
+
 func TestSetlocation(t *testing.T) {
 	//nolint: gocritic
 //line types_test.go:10
@@ -26,7 +32,7 @@ func TestSetlocation(t *testing.T) {
         DATA: values differ
         	     got: 12
         	expected: 13
-`)
+`+thisIsHowWeGotHere(11))
 	} else {
 		t.Error("Cmp returned true!")
 	}
@@ -45,7 +51,7 @@ func TestSetlocation(t *testing.T) {
         	              14,
         	              15)
         [under operator Any at types_test.go:23]
-`)
+`+thisIsHowWeGotHere(21))
 	} else {
 		t.Error("Cmp returned true!")
 	}
@@ -63,7 +69,7 @@ func TestSetlocation(t *testing.T) {
         	expected: Any(13,
         	              14,
         	              15)
-`)
+`+thisIsHowWeGotHere(31))
 	} else {
 		t.Error("CmpAny returned true!")
 	}
@@ -83,7 +89,7 @@ func TestSetlocation(t *testing.T) {
         	              14,
         	              15)
         [under operator Any at types_test.go:44]
-`)
+`+thisIsHowWeGotHere(42))
 	} else {
 		t.Error("Cmp returned true!")
 	}
@@ -102,7 +108,7 @@ func TestSetlocation(t *testing.T) {
         	expected: Any(13,
         	              14,
         	              15)
-`)
+`+thisIsHowWeGotHere(52))
 	} else {
 		t.Error("Cmp returned true!")
 	}


### PR DESCRIPTION
- feat(tdsynctest): add Subtest, SubtestAssertRequire and Sleep functions
- fix: starting go1.27, the first file of the stack trace is a full path\
  So the paragraph "This is how we got here:" is added by go-testdeep to
  report failures when the file containing the failure is not in the
  module root directory.
- test(Smuggle): starting go1.27, json.RawMessage = jsontext.Value\
  So the name of type json.RawMessage is jsontext.Value.
